### PR TITLE
New Features: user defined colors for target and saving interactive heatmap

### DIFF
--- a/fgclustering/forest_guided_clustering.py
+++ b/fgclustering/forest_guided_clustering.py
@@ -213,7 +213,7 @@ class FgClustering:
         )
 
     def plot_feature_importance(
-        self, thr_pvalue: float = 1, top_n: int = None, num_cols: int = 4, save: str = None
+        self, thr_pvalue: float = 1, top_n: int = None, num_cols: int = 4, save: str = None, cmap_target_dict: dict = None
     ):
         """
         Plot feature importance based on p-values for global and local feature importance.
@@ -238,6 +238,8 @@ class FgClustering:
         :type num_cols: int, optional
         :param save: Filename to save the plot. If None, the plot will not be saved. Defaults to None.
         :type save: str, optional
+        :param cmap_target_dict: Dict of colours to map categorical targets
+        :type cmap_target_dict: dict
         """
 
         # select top n features for plotting
@@ -252,6 +254,7 @@ class FgClustering:
             top_n,
             num_cols,
             save,
+            cmap_target_dict
         )
 
     def plot_decision_paths(
@@ -263,6 +266,7 @@ class FgClustering:
         top_n: int = None,
         num_cols: int = 6,
         save: str = None,
+        cmap_target_dict: dict = None
     ):
         """
         Plot decision paths of the Random Forest model. This function generates visualizations
@@ -289,6 +293,8 @@ class FgClustering:
         :type num_cols: int, optional
         :param save: Filename to save the plot. If `None`, the figure is not saved, defaults to `None`.
         :type save: str, optional
+        :param cmap_target_dict: Dict of colours to map categorical targets
+        :type cmap_target_dict: dict
         """
         # drop insignificant features
         selected_features = self.p_value_of_features_ranked.loc["p_value"] < thr_pvalue
@@ -302,7 +308,7 @@ class FgClustering:
 
         if distributions:
             plotting._plot_distributions(
-                self.data_clustering_ranked[selected_features], thr_pvalue, top_n, num_cols, save
+                self.data_clustering_ranked[selected_features], thr_pvalue, top_n, num_cols, save, cmap_target_dict
             )
 
         if heatmap:
@@ -321,4 +327,5 @@ class FgClustering:
                     top_n,
                     heatmap_type,
                     save,
+                    cmap_target_dict,
                 )

--- a/fgclustering/plotting.py
+++ b/fgclustering/plotting.py
@@ -103,7 +103,7 @@ def _plot_feature_importance(
 
 
 def _plot_distributions(
-    data_clustering_ranked: pd.DataFrame, thr_pvalue: float, top_n: int, num_cols: int, save: str
+    data_clustering_ranked: pd.DataFrame, thr_pvalue: float, top_n: int, num_cols: int, save: str, cmap_target_dict: dict
 ):
     """Plot feature boxplots (for continuous features) or barplots (for categorical features) divided by clusters,
     where features are filtered and ranked by p-value of a statistical test (ANOVA for continuous features,
@@ -117,6 +117,8 @@ def _plot_distributions(
     :type num_cols: int
     :param save: Filename to save plot.
     :type save: str
+    :param cmap_target_dict: Dict of colours to map categorical targets
+    :type cmap_target_dict: dict
     """
     features_to_plot = data_clustering_ranked.drop("cluster", axis=1, inplace=False).columns.to_list()
 
@@ -129,6 +131,12 @@ def _plot_distributions(
         fontsize=14,
     )
 
+    if cmap_target_dict is not None:
+        color_palette = sns.color_palette(list(cmap_target_dict.values()))
+        cmap_target = sns.color_palette(color_palette, as_cmap=True)
+    else:
+        cmap_target = "Blues_r"
+
     for n, feature in enumerate(features_to_plot):
         # add a new subplot iteratively
         ax = plt.subplot(num_rows, num_cols, n + 1)
@@ -140,7 +148,7 @@ def _plot_distributions(
                 hue=feature,
                 data=data_clustering_ranked,
                 ax=ax,
-                palette="Blues_r",
+                palette=cmap_target,
             )
             ax.set_title(f"Feature: {feature}")
             ax.legend(bbox_to_anchor=(1, 1), loc=2)
@@ -167,6 +175,7 @@ def _plot_heatmap_classification(
     top_n: int,
     heatmap_type: str,
     save: str,
+    cmap_target_dict: dict
 ):
     """
     Generates a classification heatmap visualization for clustered data, supporting both static and interactive plots.
@@ -182,7 +191,8 @@ def _plot_heatmap_classification(
     :type heatmap_type: str
     :param save: File path for saving the heatmap. Only supported for static heatmaps.
     :type save: str
-    :raises RuntimeError: If `heatmap_type` is "interactive" and `save` is specified, as saving interactive plots is not implemented.
+    :param cmap_target_dict: Dict of colours to map categorical targets
+    :type cmap_target_dict: dict
     :return: None
     """
     cluster_labels = data_clustering_ranked["cluster"]
@@ -205,11 +215,17 @@ def _plot_heatmap_classification(
         target, top_n, thr_pvalue
     )
 
+
     if heatmap_type == "static":
         # Get plotting settings
 
-        color_palette = sns.color_palette(target_color, n_colors=len(categories))
-        cmap_target = sns.color_palette(color_palette, as_cmap=True)
+        if cmap_target_dict is not None:
+            color_palette = sns.color_palette(list(cmap_target_dict.values()))
+            cmap_target = sns.color_palette(color_palette, as_cmap=True)
+        else:
+            color_palette = sns.color_palette(target_color, n_colors=len(categories))
+            cmap_target = sns.color_palette(color_palette, as_cmap=True)
+
         color_map = {i: color_palette[i] for i in range(len(categories))}
 
         fig, ax_target, ax_target_cb, ax_features, ax_features_cb, target_plot, feature_plot = (
@@ -245,11 +261,19 @@ def _plot_heatmap_classification(
         plt.show()
 
     elif heatmap_type == "interactive":
-        # Create a color scale for the target categories
-        color_palette_rgb = [
-            f"rgb({int(r * 255)},{int(g * 255)},{int(b * 255)})"
-            for r, g, b in sns.color_palette(target_color, n_colors=len(categories))
-        ]
+        if cmap_target_dict is not None:
+            # Create a color scale for the target categories
+            color_palette_rgb = [
+                f"rgb({int(r * 255)},{int(g * 255)},{int(b * 255)})"
+                for r, g, b in sns.color_palette(list(cmap_target_dict.values()))
+            ]
+        else:
+            # Create a color scale for the target categories
+            color_palette_rgb = [
+                f"rgb({int(r * 255)},{int(g * 255)},{int(b * 255)})"
+                for r, g, b in sns.color_palette(target_color, n_colors=len(categories))
+            ]
+
         color_map = {i: color_palette_rgb[i] for i in range(len(categories))}
         colorscale = [[i / (len(categories) - 1), color_map[i]] for i in range(len(categories))]
 
@@ -277,12 +301,11 @@ def _plot_heatmap_classification(
                     name=category,
                 )
             )
-        fig.show()
 
         if save:
-            raise RuntimeError(
-                "Saving interactive plots is not implemented. Please set heatmap_type='static' to save the plot."
-            )
+            fig.write_html(f"{save}_heatmap.html")
+        else:
+            fig.show()
 
 
 def _plot_heatmap_regression(


### PR DESCRIPTION
New argument for the plots: cmap_target_dict. It expects a dictionary with the exhaustive {target: color} mapping. Color could be str or tuple, which is understandable by matplotlib.colors. It plots the colors on feat_importance bar plots (top left corner) and also on the static and interactive classification heatmap. Not implemented for regression type heatmap yet. If cmap_target_dict is None, it plots the default colors ("Blues_r" for count plot and "Greens" for heatmap). 

If save is given for interactive heatmap, it saves to a html file instead of throwing an exception. Otherwise, it shows the fig.

Tested, works.