### PR TITLE
34 enhancement improve memory efficiency and runtime in distance computation and stability evaluation

### DIFF
--- a/.github/scripts/ci_python_versions.py
+++ b/.github/scripts/ci_python_versions.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Extract supported Python versions from pyproject.toml's
+[project].requires-python field and emit a JSON list.
+
+Expected format:
+    ">=3.10,<3.14"
+
+Example output:
+    ["3.10", "3.11", "3.12", "3.13"]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def main() -> None:
+    try:
+        import tomllib  # Python >=3.11
+    except ModuleNotFoundError:
+        raise SystemExit("tomllib not available. This script must run with Python >= 3.11.")
+
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        raise SystemExit("pyproject.toml not found in repository root.")
+
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    try:
+        requires_python = data["project"]["requires-python"]
+    except KeyError:
+        raise SystemExit("Missing 'project.requires-python' in pyproject.toml.")
+
+    # Expect format like: ">=3.10,<3.14"
+    min_match = re.search(r">=\s*3\.(\d+)", requires_python)
+    max_match = re.search(r"<\s*3\.(\d+)", requires_python)
+
+    if not (min_match and max_match):
+        raise SystemExit(
+            f"Unsupported requires-python format: {requires_python!r}. "
+            "Expected format like '>=3.10,<3.14'."
+        )
+
+    min_minor = int(min_match.group(1))
+    max_minor = int(max_match.group(1))  # exclusive
+
+    if min_minor >= max_minor:
+        raise SystemExit(f"Invalid Python version range: {requires_python!r}")
+
+    versions = [f"3.{minor}" for minor in range(min_minor, max_minor)]
+
+    # Print pure JSON for GitHub Actions consumption
+    print(json.dumps(versions))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11' # python-version: '3.x' (for latest Python versions)
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,32 +6,49 @@ on:
       - main
     paths-ignore:
       - 'README.md'
-      - 'pyproject.toml'
       - 'docs/**'
       - 'tutorials/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'README.md'
-      - 'pyproject.toml'
       - 'docs/**'
       - 'tutorials/**'
-      - '.github/workflows/**'
   workflow_dispatch:
   workflow_call:
 
 jobs:
+
+  matrix:
+    name: Build python-version matrix from pyproject.toml
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.set-matrix.outputs.python-versions }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python (for parsing)
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - id: set-matrix
+        name: Parse requires-python and emit versions
+        shell: bash
+        run: |
+          echo "python-versions=$(python .github/scripts/ci_python_versions.py)" >> "$GITHUB_OUTPUT"
+
   build:
-  
+    needs: matrix
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 12
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8","3.9", "3.10", "3.11", "3.12", "3.13"]
-        
+        python-version: ${{ fromJSON(needs.matrix.outputs.python-versions) }}  
     steps:
     - name: Checkout Repository 
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
       python-versions: ${{ steps.set-matrix.outputs.python-versions }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python (for parsing)
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -51,10 +51,10 @@ jobs:
         python-version: ${{ fromJSON(needs.matrix.outputs.python-versions) }}  
     steps:
     - name: Checkout Repository 
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,53 +1,60 @@
-# This CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to generate yours today!
-
 cff-version: 1.2.0
 title: >-
-  Forest-Guided Clustering - Explainability for
-  Random Forest Models
+  Forest-Guided Clustering — Shedding Light into the Random Forest Black Box
 message: >-
-  "If you use this software, please cite it as
-  below."
+  If you use this software in your research or applications, please cite the 
+  associated preprint below.
+
 type: software
+
 authors:
   - given-names: Lisa
     family-names: Barros de Andrade e Sousa
     email: lisa.barros.andrade.sousa@gmail.com
     affiliation: Helmholtz AI
-    orcid: 'https://orcid.org/0000-0001-7702-9782'
+    orcid: "https://orcid.org/0000-0001-7702-9782"
+  - given-names: Gregor
+    family-names: Miller
+  - given-names: Ronan
+    family-names: Le Gleut
   - given-names: Dominik
     family-names: Thalmeier
   - given-names: Helena
     family-names: Pelin
-    email: helena.pelin@helmholtz-muenchen.de
-    affiliation: Helmholtz AI
-    orcid: 'https://orcid.org/0000-0001-8875-4285'
   - given-names: Marie
     family-names: Piraud
+    affiliation: Helmholtz AI
+
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.6445529
+    value: 10.48550/arXiv.2507.19455
+
 repository-code: >-
   https://github.com/HelmholtzAI-Consultants-Munich/fg-clustering
 url: >-
   https://forest-guided-clustering.readthedocs.io/en/latest/
+
 abstract: >-
-  This python package is about explainability of
-  Random Forest models. Standard explainability
-  methods (e.g. feature importance) assume
-  independence of model features and hence, are not
-  suited in the presence of correlated features. The
-  Forest-Guided Clustering algorithm does not assume
-  independence of model features, because it computes
-  the feature importance based on subgroups of
-  instances that follow similar decision rules within
-  the Random Forest model. Hence, this method is well
-  suited for cases with high correlation among model
-  features.
+  Random Forests (RF), despite their widespread use and strong performance on 
+  tabular data, remain difficult to interpret due to their ensemble nature. We 
+  present Forest-Guided Clustering (FGC), a model-specific explainability method 
+  that reveals both local and global structure in RFs by grouping instances 
+  according to shared decision paths. FGC produces human-interpretable clusters 
+  aligned with the model's internal logic and computes cluster-specific and 
+  global feature importance scores to derive decision rules underlying RF 
+  predictions. FGC accurately recovered latent subclass structure on a benchmark 
+  dataset and outperformed classical clustering and post-hoc explanation methods. 
+  Applied to an AML transcriptomic dataset, FGC uncovered biologically coherent 
+  subpopulations, disentangled disease-relevant signals from confounders, and 
+  recovered known and novel gene expression patterns. FGC bridges the gap 
+  between performance and interpretability by providing structure-aware insights 
+  that go beyond feature-level attribution. :contentReference[oaicite:1]{index=1}
+
 keywords:
   - XAI
   - explainable machine learning
   - Random Forest
+  - clustering
+  - model interpretability
+
 license: MIT
-version: v0.2.0
-date-released: '2022-04-11'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -48,7 +48,7 @@ abstract: >-
   subpopulations, disentangled disease-relevant signals from confounders, and 
   recovered known and novel gene expression patterns. FGC bridges the gap 
   between performance and interpretability by providing structure-aware insights 
-  that go beyond feature-level attribution. :contentReference[oaicite:1]{index=1}
+  that go beyond feature-level attribution.
 
 keywords:
   - XAI

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Helmholtz AI
+Copyright (c) 2026 Helmholtz AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Visit our [full documentation](https://forest-guided-clustering.readthedocs.io/)
 
 **Requirements**
 
-This package was tested for `Python 3.8 - 3.13` on ubuntu, macos and windows. It depends on the `kmedoids` python package. If you are using windows or macos, you may need to first install Rust/Cargo with:
+This package was tested for `Python 3.10 - 3.13` on ubuntu, macos and windows. It depends on the `kmedoids` python package. If you are using windows or macos, you may need to first install Rust/Cargo with:
 
     conda install -c conda-forge rust
 

--- a/fgclustering/clustering.py
+++ b/fgclustering/clustering.py
@@ -308,7 +308,11 @@ def _calculate_inertia(
 
         for j in range(n_medoids):
             medoid = medoids_idx[j]
-            proximity = np.sum(terminals[sample, :] == terminals[medoid, :])
+            # use explicit loop for proximity to avoid temporary array allocation and minimize memory traffic
+            proximity = 0
+            for t in range(n_estimators):
+                if terminals[sample, t] == terminals[medoid, t]:
+                    proximity += 1
             distances[j] = 1.0 - (proximity / n_estimators)
 
         inertia[i] = np.min(distances)

--- a/fgclustering/clustering.py
+++ b/fgclustering/clustering.py
@@ -68,7 +68,7 @@ class ClusteringKMedoids:
         :param distance_metric: An instance of DistanceRandomForestProximity with precomputed terminals.
         :type distance_metric: DistanceRandomForestProximity
         :param sample_indices: Indices of the samples to include in clustering.
-        :type sample_indices: numpy.ndarray
+        :type sample_indices: np.ndarray
         :param random_state_subsampling: Random seed for for subsampling reproducibility. Not used in this implementation.
         :type random_state_subsampling: int | None
         :param verbose: Verbosity level (0 = silent, 1 = progress messages). Not used in this implementation.
@@ -77,7 +77,7 @@ class ClusteringKMedoids:
         :raises ValueError: If terminal nodes are not precomputed in the distance metric.
 
         :return: Cluster labels for each input sample index.
-        :rtype: numpy.ndarray
+        :rtype: np.ndarray
         """
         if distance_metric.terminals is None:
             raise ValueError("Terminals need to be precomputed!")
@@ -169,7 +169,7 @@ class ClusteringClara:
         :param distance_metric: An instance of DistanceRandomForestProximity with precomputed terminals.
         :type distance_metric: DistanceRandomForestProximity
         :param sample_indices: Indices of the samples to include in clustering.
-        :type sample_indices: numpy.ndarray
+        :type sample_indices: np.ndarray
         :param random_state_subsampling: Random seed for for subsampling reproducibility. If None, use `random_state` defined in constructor.
         :type random_state_subsampling: int | None
         :param verbose: Verbosity level (0 = silent, 1 = progress messages).
@@ -178,7 +178,7 @@ class ClusteringClara:
         :raises ValueError: If terminal nodes are not precomputed in the distance metric.
 
         :return: Cluster labels for each input sample index.
-        :rtype: numpy.ndarray
+        :rtype: np.ndarray
         """
         if distance_metric.terminals is None:
             raise ValueError("Terminals need to be precomputed!")
@@ -277,7 +277,7 @@ class ClusteringClara:
 ############################################
 
 
-@njit(parallel=True, fastmath=True)
+@njit(parallel=True)
 def _calculate_inertia(
     terminals: np.ndarray,
     sample_idx: np.ndarray,
@@ -288,11 +288,11 @@ def _calculate_inertia(
     where distances are defined as Random Forest proximity-based distances.
 
     :param terminals: 2D array of shape (n_samples, n_estimators), where each entry indicates the terminal node index for a sample in a tree.
-    :type terminals: numpy.ndarray
+    :type terminals: np.ndarray
     :param sample_idx: Indices of samples for which inertia is calculated.
-    :type sample_idx: numpy.ndarray
+    :type sample_idx: np.ndarray
     :param medoids_idx: Indices of medoids used to calculate inertia.
-    :type medoids_idx: numpy.ndarray
+    :type medoids_idx: np.ndarray
 
     :return: Total inertia value for the sample set.
     :rtype: float
@@ -316,7 +316,7 @@ def _calculate_inertia(
     return np.sum(inertia)
 
 
-@njit(parallel=True, fastmath=True)
+@njit(parallel=True)
 def _asign_labels(
     terminals: np.ndarray,
     sample_idx: np.ndarray,
@@ -326,14 +326,14 @@ def _asign_labels(
     Assign each sample to the cluster of the closest medoid based on Random Forest proximity-based distances.
 
     :param terminals: 2D array of shape (n_samples, n_estimators), where each entry indicates the terminal node index for a sample in a tree.
-    :type terminals: numpy.ndarray
+    :type terminals: np.ndarray
     :param sample_idx: Indices of the samples to assign to clusters.
-    :type sample_idx: numpy.ndarray
+    :type sample_idx: np.ndarray
     :param medoids_idx: Indices of medoids used to assign cluster labels.
-    :type medoids_idx: numpy.ndarray
+    :type medoids_idx: np.ndarray
 
     :return: Cluster labels for each input sample index.
-    :rtype: numpy.ndarray
+    :rtype: np.ndarray
     """
     n_estimators = terminals.shape[1]
     n_samples = len(sample_idx)
@@ -346,7 +346,11 @@ def _asign_labels(
 
         for j in range(n_medoids):
             medoid = medoids_idx[j]
-            proximity = np.sum(terminals[sample, :] == terminals[medoid, :])
+            # use explicit loop for proximity to avoid temporary array allocation and minimize memory traffic
+            proximity = 0
+            for t in range(n_estimators):
+                if terminals[sample, t] == terminals[medoid, t]:
+                    proximity += 1
             cluster_label_sample[j] = 1.0 - (proximity / n_estimators)
 
         cluster_labels[i] = np.argmin(cluster_label_sample)

--- a/fgclustering/clustering.py
+++ b/fgclustering/clustering.py
@@ -7,7 +7,6 @@ import gc
 import kmedoids
 import numpy as np
 
-from typing import Optional, Union
 from numba import njit, prange
 
 from imblearn.under_sampling import RandomUnderSampler
@@ -29,21 +28,21 @@ class ClusteringKMedoids:
     on the fly using Random Forest terminal nodes.
 
     :param method: Computation method for the K-Medoids algorithm. Default: "fasterpam".
-    :type method: Optional[str]
+    :type method: str
     :param init: Initialization strategy for the K-Medoids algorithm. Default: "random".
-    :type init: Optional[str]
+    :type init: str
     :param max_iter: Maximum number of iterations for the K-Medoids algorithm. Default: 100.
-    :type max_iter: Optional[int]
+    :type max_iter: int
     :param random_state: Random seed for reproducibility. Default: 42.
-    :type random_state: Optional[int]
+    :type random_state: int
     """
 
     def __init__(
         self,
-        method: Optional[str] = "fasterpam",
-        init: Optional[str] = "random",
-        max_iter: Optional[int] = 100,
-        random_state: Optional[int] = 42,
+        method: str = "fasterpam",
+        init: str = "random",
+        max_iter: int = 100,
+        random_state: int = 42,
     ) -> None:
         """Constructor for the ClusteringKMedoids class."""
         self.method = method
@@ -57,7 +56,7 @@ class ClusteringKMedoids:
         k: int,
         distance_metric: DistanceRandomForestProximity,
         sample_indices: np.ndarray,
-        random_state_subsampling: Union[int, None],
+        random_state_subsampling: int | None,
         verbose: int,
     ) -> np.ndarray:
         """
@@ -71,7 +70,7 @@ class ClusteringKMedoids:
         :param sample_indices: Indices of the samples to include in clustering.
         :type sample_indices: numpy.ndarray
         :param random_state_subsampling: Random seed for for subsampling reproducibility. Not used in this implementation.
-        :type random_state_subsampling: Union[int, None]
+        :type random_state_subsampling: int | None
         :param verbose: Verbosity level (0 = silent, 1 = progress messages). Not used in this implementation.
         :type verbose: int
 
@@ -114,30 +113,30 @@ class ClusteringClara:
     computed on demand from precomputed Random Forest terminal node assignments.
 
     :param sub_sample_size: Number or proportion of samples to draw for each CLARA iteration. If None, computes an adaptive subsample ratio based on dataset size, constrained between 10% and 80%, targeting approximately 1,000 samples. Default: None.
-    :type sub_sample_size: Optional[Union[int, float]]
+    :type sub_sample_size: int | float | None
     :param sampling_iter: Number of CLARA iterations to perform. If None, sets the number of sampling iterations log2(sample size), with a minimum of 5 iterations to ensure sufficient sampling. Default: None.
-    :type sampling_iter: Optional[int]
+    :type sampling_iter: int | None
     :param sampling_target: List of target class labels for stratified subsampling. If provided, ensures that the subsample maintains the class distribution of the original dataset. Default: None.
-    :type sampling_target: Optional[list]
+    :type sampling_target: list | None
     :param method: Computation method for the K-Medoids algorithm. Default: "fasterpam".
-    :type method: Optional[str]
+    :type method: str
     :param init: Initialization strategy for the K-Medoids algorithm. Default: "random".
-    :type init: Optional[str]
+    :type init: str
     :param max_iter: Maximum number of iterations for the K-Medoids algorithm. Default: 100.
-    :type max_iter: Optional[int]
+    :type max_iter: int
     :param random_state: Random seed for reproducibility. Default: 42.
-    :type random_state: Optional[int]
+    :type random_state: int
     """
 
     def __init__(
         self,
-        sub_sample_size: Optional[Union[int, float]] = None,
-        sampling_iter: Optional[int] = None,
-        sampling_target: Optional[list] = None,
-        method: Optional[str] = "fasterpam",
-        init: Optional[str] = "random",
-        max_iter: Optional[int] = 100,
-        random_state: Optional[int] = 42,
+        sub_sample_size: int | float | None = None,
+        sampling_iter: int | None = None,
+        sampling_target: list | None = None,
+        method: str = "fasterpam",
+        init: str = "random",
+        max_iter: int = 100,
+        random_state: int = 42,
     ) -> None:
         """Constructor for the ClusteringClara class."""
         self.sub_sample_size = sub_sample_size
@@ -156,7 +155,7 @@ class ClusteringClara:
         k: int,
         distance_metric: DistanceRandomForestProximity,
         sample_indices: np.ndarray,
-        random_state_subsampling: Union[int, None],
+        random_state_subsampling: int | None,
         verbose: int,
     ) -> np.ndarray:
         """
@@ -172,7 +171,7 @@ class ClusteringClara:
         :param sample_indices: Indices of the samples to include in clustering.
         :type sample_indices: numpy.ndarray
         :param random_state_subsampling: Random seed for for subsampling reproducibility. If None, use `random_state` defined in constructor.
-        :type random_state_subsampling: Union[int, None]
+        :type random_state_subsampling: int | None
         :param verbose: Verbosity level (0 = silent, 1 = progress messages).
         :type verbose: int
 

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -60,7 +60,7 @@ class DistanceRandomForestProximity:
         :param estimator: A trained Random Forest estimator from sklearn.
         :type estimator: RandomForestClassifier | RandomForestRegressor
         :param X: Input feature matrix.
-        :type X: pandas.DataFrame
+        :type X: pd.DataFrame
         """
         self.terminals = estimator.apply(X).astype(np.int32)
 
@@ -81,7 +81,7 @@ class DistanceRandomForestProximity:
         :raises MemoryError: If insufficient disk space is available to store the memmap distance matrix.
 
         :return: A symmetric distance matrix with pairwise distances between samples.
-        :rtype: tuple[numpy.ndarray | numpy.memmap, str | None]
+        :rtype: tuple[np.ndarray | np.memmap, str | None]
         """
         if self.terminals is None:
             raise ValueError(
@@ -124,7 +124,7 @@ class DistanceRandomForestProximity:
         file locking issues, especially on Windows.
 
         :param distance_matrix: The distance matrix object to delete.
-        :type distance_matrix: numpy.ndarray | numpy.memmap
+        :type distance_matrix: np.ndarray | np.memmap
         :param file_distance_matrix: Full path to the memmap file on disk.
         :type file_distance_matrix: str | None
         """
@@ -170,10 +170,10 @@ class DistanceWasserstein:
         Scales all numeric features in the dataset using standard scaling (without centering the mean).
 
         :param X: Input feature matrix.
-        :type X: pandas.DataFrame
+        :type X: pd.DataFrame
 
         :return: Input feature matrix with numeric columns transformed.
-        :rtype: pandas.DataFrame
+        :rtype: pd.DataFrame
         """
         scaler = StandardScaler(with_mean=False)
         numeric_cols = X.select_dtypes(include="number").columns
@@ -193,9 +193,9 @@ class DistanceWasserstein:
         categorical features (returning max distance) and raw values for numerical ones.
 
         :param values_background: Feature values from the full dataset (background distribution).
-        :type values_background: pandas.Series
+        :type values_background: pd.Series
         :param values_cluster: Feature values for the current cluster.
-        :type values_cluster: pandas.Series
+        :type values_cluster: pd.Series
         :param is_categorical: Indicates whether the feature is categorical.
         :type is_categorical: bool
 
@@ -240,10 +240,10 @@ class DistanceJensenShannon:
         Scales all numeric features in the dataset using standard scaling (without centering the mean).
 
         :param X: Input feature matrix.
-        :type X: pandas.DataFrame
+        :type X: pd.DataFrame
 
         :return: Input feature matrix with numeric columns transformed.
-        :rtype: pandas.DataFrame
+        :rtype: pd.DataFrame
         """
         scaler = StandardScaler(with_mean=False)
         numeric_cols = X.select_dtypes(include="number").columns
@@ -263,9 +263,9 @@ class DistanceJensenShannon:
         features and histograms for numerical ones.
 
         :param values_background: Feature values from the full dataset (background distribution).
-        :type values_background: pandas.Series
+        :type values_background: pd.Series
         :param values_cluster: Feature values for the current cluster.
-        :type values_cluster: pandas.Series
+        :type values_cluster: pd.Series
         :param is_categorical: Indicates whether the feature is categorical.
         :type is_categorical: bool
 
@@ -308,7 +308,7 @@ class DistanceJensenShannon:
 ############################################
 
 
-@njit(parallel=True, fastmath=True)
+@njit(parallel=True)
 def _calculate_distances(
     terminals: np.ndarray,
     n: int,
@@ -323,23 +323,31 @@ def _calculate_distances(
     symmetric without a separate transpose step.
 
     :param terminals: 2D array of shape (n_samples, n_estimators), where each entry indicates the terminal node index for a sample in a tree.
-    :type terminals: numpy.ndarray
+    :type terminals: np.ndarray
     :param n: Number of samples.
     :type n: int
     :param n_estimators: Number of trees in the Random Forest model.
     :type n_estimators: int
     :param distance_matrix: Pre-allocated 2D array where the resulting distances will be stored.
-    :type distance_matrix: numpy.ndarray | numpy.memmap
+    :type distance_matrix: np.ndarray | np.memmap
 
     :return: The updated symmetric distance matrix with pairwise distances.
-    :rtype: numpy.ndarray | numpy.memmap
+    :rtype: np.ndarray | np.memmap
     """
     for i in prange(n):
-        for j in range(i + 1, n):  # no prange here due to write conflicts
-            proximity = np.sum(terminals[i, :] == terminals[j, :])
+        for j in range(i + 1, n):
+            # use explicit loop for proximity to avoid temporary array allocation and minimize memory traffic
+            proximity = 0
+            for t in range(n_estimators):
+                if terminals[i, t] == terminals[j, t]:
+                    proximity += 1
+
             distance = 1.0 - (proximity / n_estimators)
-            if distance > 0:
-                distance_matrix[i, j] = distance
-                distance_matrix[j, i] = distance
+            distance_matrix[i, j] = distance
+
+    # Fill lower triangle in a separate pass to ensure symmetry without race conditions (if done inside prange loop) and without allocating a full transpose.
+    for i in range(n):
+        for j in range(i + 1, n):
+            distance_matrix[j, i] = distance_matrix[i, j]
 
     return distance_matrix

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -9,7 +9,6 @@ import uuid
 import numpy as np
 import pandas as pd
 
-from typing import Optional, Union
 from numba import njit, prange
 
 from scipy.stats import wasserstein_distance
@@ -30,15 +29,15 @@ class DistanceRandomForestProximity:
     Supports both in-memory and memory-efficient computation via disk-backed memmap arrays.
 
     :param memory_efficient: Whether to store the distance matrix in a memory-efficient way using a disk-based memmap. Default: False.
-    :type memory_efficient: Optional[bool]
+    :type memory_efficient: bool
     :param dir_distance_matrix: Directory path where the distance matrix should be stored when using memory-efficient mode. Default: None.
-    :type dir_distance_matrix: Optional[str]
+    :type dir_distance_matrix: str | None
     """
 
     def __init__(
         self,
-        memory_efficient: Optional[bool] = False,
-        dir_distance_matrix: Optional[str] = None,
+        memory_efficient: bool = False,
+        dir_distance_matrix: str | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestProximity class."""
         if memory_efficient:
@@ -52,14 +51,14 @@ class DistanceRandomForestProximity:
 
     def calculate_terminals(
         self,
-        estimator: Union[RandomForestClassifier, RandomForestRegressor],
+        estimator: RandomForestClassifier | RandomForestRegressor,
         X: pd.DataFrame,
     ) -> None:
         """
         Calculates and stores the terminal nodes of all samples across all trees in the Random Forest.
 
         :param estimator: A trained Random Forest estimator from sklearn.
-        :type estimator: Union[sklearn.ensemble.RandomForestClassifier, RandomForestRegressor]
+        :type estimator: RandomForestClassifier | RandomForestRegressor
         :param X: Input feature matrix.
         :type X: pandas.DataFrame
         """
@@ -67,8 +66,8 @@ class DistanceRandomForestProximity:
 
     def calculate_distance_matrix(
         self,
-        sample_indices: Union[np.ndarray, None],
-    ) -> Union[np.ndarray, np.memmap]:
+        sample_indices: np.ndarray | None,
+    ) -> tuple[np.ndarray | np.memmap, str | None]:
         """
         Computes the pairwise distance matrix between samples based on terminal node similarity
         derived from Random Forest models, where distance is defined as one minus the fraction
@@ -76,13 +75,13 @@ class DistanceRandomForestProximity:
         Optionally uses a disk-backed memmap array if `memory_efficient=True`.
 
         :param sample_indices: Indices of samples for which distance is calculated. If None, uses all samples.
-        :type sample_indices: Union[np.ndarray, None]
+        :type sample_indices: np.ndarray | None
 
         :raises ValueError: If terminal nodes have not been precomputed.
         :raises MemoryError: If insufficient disk space is available to store the memmap distance matrix.
 
         :return: A symmetric distance matrix with pairwise distances between samples.
-        :rtype: Union[numpy.ndarray, numpy.memmap]
+        :rtype: tuple[numpy.ndarray | numpy.memmap, str | None]
         """
         if self.terminals is None:
             raise ValueError(
@@ -118,8 +117,8 @@ class DistanceRandomForestProximity:
 
     def remove_distance_matrix(
         self,
-        distance_matrix: Union[np.ndarray, np.memmap],
-        file_distance_matrix: str,
+        distance_matrix: np.ndarray | np.memmap,
+        file_distance_matrix: str | None,
     ) -> None:
         """
         Removes the disk-backed distance matrix file if memory-efficient mode is enabled
@@ -127,9 +126,9 @@ class DistanceRandomForestProximity:
         file locking issues, especially on Windows.
 
         :param distance_matrix: The distance matrix object to delete.
-        :type distance_matrix: Union[numpy.ndarray, numpy.memmap]
+        :type distance_matrix: numpy.ndarray | numpy.memmap
         :param file_distance_matrix: Full path to the memmap file on disk.
-        :type file_distance_matrix: str
+        :type file_distance_matrix: str | None
         """
         try:
             distance_matrix.flush()
@@ -316,8 +315,8 @@ def _calculate_distances(
     terminals: np.ndarray,
     n: int,
     n_estimators: int,
-    distance_matrix: Union[np.ndarray, np.memmap],
-) -> Union[np.ndarray, np.memmap]:
+    distance_matrix: np.ndarray | np.memmap,
+) -> np.ndarray | np.memmap:
     """
     Computes the upper triangle of a pairwise distance matrix based on Random Forest terminal node similarity.
 
@@ -332,10 +331,10 @@ def _calculate_distances(
     :param n_estimators: Number of trees in the Random Forest model.
     :type n_estimators: int
     :param distance_matrix: Pre-allocated 2D array where the resulting distances will be stored.
-    :type distance_matrix: Union[numpy.ndarray, numpy.memmap]
+    :type distance_matrix: numpy.ndarray | numpy.memmap
 
     :return: The updated distance matrix with the upper triangle filled with computed distances.
-    :rtype: Union[numpy.ndarray, numpy.memmap]
+    :rtype: numpy.ndarray | numpy.memmap
     """
     for i in prange(n):
         for j in range(i + 1, n):  # no prange here due to write conflicts

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -107,12 +107,10 @@ class DistanceRandomForestProximity:
                 distance_matrix = np.memmap(file_distance_matrix, dtype=np.float32, mode="w+", shape=(n, n))
             else:
                 file_distance_matrix = None
-                distance_matrix = np.zeros((n, n))
+                distance_matrix = np.zeros((n, n), dtype=np.float32)
 
             distance_matrix = _calculate_distances(terminals, n, n_estimators, distance_matrix)
 
-            # Ensure symmetry
-            distance_matrix += distance_matrix.T
             return distance_matrix, file_distance_matrix
 
     def remove_distance_matrix(
@@ -318,11 +316,11 @@ def _calculate_distances(
     distance_matrix: np.ndarray | np.memmap,
 ) -> np.ndarray | np.memmap:
     """
-    Computes the upper triangle of a pairwise distance matrix based on Random Forest terminal node similarity.
+    Computes a symmetric pairwise distance matrix based on Random Forest terminal node similarity.
 
     The distance between two samples is defined as one minus the fraction of trees in which both samples
-    fall into the same terminal node. Only the upper triangle of the matrix is computed to avoid redundant
-    calculations as the resulting matrix is symmetric.
+    fall into the same terminal node. Both (i, j) and (j, i) are filled in the loop so the matrix is
+    symmetric without a separate transpose step.
 
     :param terminals: 2D array of shape (n_samples, n_estimators), where each entry indicates the terminal node index for a sample in a tree.
     :type terminals: numpy.ndarray
@@ -333,7 +331,7 @@ def _calculate_distances(
     :param distance_matrix: Pre-allocated 2D array where the resulting distances will be stored.
     :type distance_matrix: numpy.ndarray | numpy.memmap
 
-    :return: The updated distance matrix with the upper triangle filled with computed distances.
+    :return: The updated symmetric distance matrix with pairwise distances.
     :rtype: numpy.ndarray | numpy.memmap
     """
     for i in prange(n):
@@ -342,5 +340,6 @@ def _calculate_distances(
             distance = 1.0 - (proximity / n_estimators)
             if distance > 0:
                 distance_matrix[i, j] = distance
+                distance_matrix[j, i] = distance
 
     return distance_matrix

--- a/fgclustering/forest_guided_clustering.py
+++ b/fgclustering/forest_guided_clustering.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-from typing import Union, Optional, Tuple, List, Any
+from typing import Any
 
 from matplotlib.figure import Figure
 from matplotlib.axes import Axes
@@ -32,18 +32,18 @@ from .plotting import (
 
 
 def forest_guided_clustering(
-    estimator: Union[RandomForestClassifier, RandomForestRegressor],
+    estimator: RandomForestClassifier | RandomForestRegressor,
     X: pd.DataFrame,
-    y: Union[str, pd.Series],
+    y: str | pd.Series,
     clustering_distance_metric: DistanceRandomForestProximity,
-    clustering_strategy: Union[ClusteringKMedoids, ClusteringClara],
-    k: Optional[Union[int, Tuple[int, int]]] = None,
-    JI_bootstrap_iter: Optional[int] = 100,
-    JI_bootstrap_sample_size: Optional[Union[int, float]] = None,
-    JI_discart_value: Optional[float] = 0.6,
-    n_jobs: Optional[int] = 1,
-    random_state: Optional[int] = 42,
-    verbose: Optional[int] = 1,
+    clustering_strategy: ClusteringKMedoids | ClusteringClara,
+    k: int | tuple[int, int] | None = None,
+    JI_bootstrap_iter: int = 100,
+    JI_bootstrap_sample_size: int | float | None = None,
+    JI_discart_value: float = 0.6,
+    n_jobs: int = 1,
+    random_state: int = 42,
+    verbose: int = 1,
 ) -> Bunch:
     """
     Perform forest-guided clustering using proximity information derived from a Random Forest model.
@@ -57,29 +57,29 @@ def forest_guided_clustering(
     stability and assigned cluster labels for each sample of the input data.
 
     :param estimator: A fitted RandomForestClassifier or RandomForestRegressor model.
-    :type estimator: Union[RandomForestClassifier, RandomForestRegressor]
+    :type estimator: RandomForestClassifier | RandomForestRegressor
     :param X: Input feature matrix.
     :type X: pandas.DataFrame
     :param y: Target variable, i.e. target values or name of the target column in X.
-    :type y: Union[str, pandas.Series]
+    :type y: str | pandas.Series
     :param clustering_distance_metric: An instance of DistanceRandomForestProximity.
     :type clustering_distance_metric: DistanceRandomForestProximity
     :param clustering_strategy: An instance of ClusteringKMedoids or ClusteringClara.
-    :type clustering_strategy: Union[ClusteringKMedoids, ClusteringClara]
+    :type clustering_strategy: ClusteringKMedoids | ClusteringClara
     :param k: If int, number of clusters is fixed. If tuple, number of clusters is optimized within the given range. If None number of clusters is optimized within the range of 2 to 6. Default: None
-    :type k: Optional[Union[int, Tuple[int, int]]]
+    :type k: int | tuple[int, int] | None
     :param JI_bootstrap_iter: Number of bootstrap iterations for Jaccard Index evaluation. Default: 100
-    :type JI_bootstrap_iter: Optional[int]
+    :type JI_bootstrap_iter: int
     :param JI_bootstrap_sample_size: Number or proportion of samples to draw for each JI bootstrap. If None, computes an adaptive subsample ratio based on dataset size, constrained between 10% and 80%, targeting approximately 1,000 samples. Default: None.
-    :type JI_bootstrap_sample_size: Optional[Union[int, float]]
+    :type JI_bootstrap_sample_size: int | float | None
     :param JI_discart_value: Jaccard Index threshold to discard unstable clusters. Default: 0.6
-    :type JI_discart_value: Optional[float]
+    :type JI_discart_value: float
     :param n_jobs: Number of parallel jobs. Default: 1.
-    :type n_jobs: Optional[int]
+    :type n_jobs: int
     :param random_state: Random seed for reproducibility. Default: 42.
-    :type random_state: Optional[int]
+    :type random_state: int
     :param verbose: Verbosity level (0 = silent, 1 = progress messages). Default: 1.
-    :type verbose: Optional[int]
+    :type verbose: int
 
     :return: A Bunch object containing k, cluster scores, cluster stability, labels, and model type.
     :rtype: Bunch
@@ -133,11 +133,11 @@ def forest_guided_clustering(
 
 def forest_guided_feature_importance(
     X: pd.DataFrame,
-    y: Union[str, pd.Series],
+    y: str | pd.Series,
     cluster_labels: np.ndarray,
     model_type: str,
-    feature_importance_distance_metric: Optional[str] = "wasserstein",
-    verbose: Optional[int] = 1,
+    feature_importance_distance_metric: str = "wasserstein",
+    verbose: int = 1,
 ) -> Bunch:
     """
     Compute forest-guided feature importance by quantifying how much each feature contributes to cluster separation.
@@ -150,15 +150,15 @@ def forest_guided_feature_importance(
     :param X: Input feature matrix.
     :type X: pandas.DataFrame
     :param y: Target variable, i.e. target values or name of the target column in X.
-    :type y: Union[str, pandas.Series]
+    :type y: str | pandas.Series
     :param cluster_labels: Labels from forest-guided clustering. Output of `forest_guided_clustering()`.
     :type cluster_labels: numpy.ndarray
     :param model_type: Type of model, either "cla" for classification or "reg" for regression. Output of `forest_guided_clustering()`.
     :type model_type: str
     :param feature_importance_distance_metric: Distance metric for computing feature importance ("wasserstein" or "jensenshannon"). Default: "wasserstein".
-    :type feature_importance_distance_metric: Optional[str]
+    :type feature_importance_distance_metric: str
     :param verbose: Verbosity level (0 = silent, 1 = progress messages). Default: 1.
-    :type verbose: Optional[int]
+    :type verbose: int
 
     :return: A Bunch object containing local feature importances, global feature importances and the clustering data ordered by the global feature importance.
     :rtype: Bunch
@@ -190,12 +190,12 @@ def forest_guided_feature_importance(
 def plot_forest_guided_feature_importance(
     feature_importance_local: pd.DataFrame,
     feature_importance_global: pd.Series,
-    top_n: Optional[int] = None,
-    num_cols: Optional[int] = 4,
-    save: Optional[str] = None,
-    reorder: Optional[bool] = False,
-    recolor: Optional[bool] = False,
-) -> Tuple[Figure, List[Axes]]:
+    top_n: int | None = None,
+    num_cols: int = 4,
+    save: str | None = None,
+    reorder: bool = False,
+    recolor: bool = False,
+) -> tuple[Figure, list[Axes]]:
     """
     Visualize global and local feature importance values as bar charts.
 
@@ -208,18 +208,18 @@ def plot_forest_guided_feature_importance(
     :param feature_importance_global: Global mean importance values across clusters. Output of `plot_forest_guided_feature_importance()`.
     :type feature_importance_global: pandas.Series
     :param top_n: If specified, number of top-ranked features to plot. Default: None.
-    :type top_n: Optional[int]
+    :type top_n: int | None
     :param num_cols: Number of columns in the subplot layout. Default: 4.
-    :type num_cols: Optional[int]
+    :type num_cols: int
     :param save: If specified, path prefix to save plots. Default: None.
-    :type save: Optional[str]
+    :type save: str | None
     :param reorder: If True, reorder the local importance values to match the global importance order.
-    :type reorder: Optional[bool]
+    :type reorder: bool
     :param recolor: If True, recolor the bars based on the global importance order.
-    :type recolor: Optional[bool]
+    :type recolor: bool
 
     :return: Matplotlib figure and axes with bar charts of global and local feature importance values.
-    :rtype: Tuple[Figure, List[Axes]]
+    :rtype: tuple[Figure, list[Axes]]
     """
     assert isinstance(feature_importance_global, pd.Series), (
         f"Expected `feature_importance_global` to be a Series, but got {type(feature_importance_global)} "
@@ -240,14 +240,14 @@ def plot_forest_guided_feature_importance(
 def plot_forest_guided_decision_paths(
     data_clustering: pd.DataFrame,
     model_type: str,
-    distributions: Optional[bool] = True,
-    heatmap: Optional[bool] = True,
-    heatmap_type: Optional[str] = "static",
-    top_n: Optional[int] = None,
-    num_cols: Optional[int] = 6,
-    cmap_target_dict: Optional[dict] = None,
-    save: Optional[str] = None,
-) -> Tuple[Optional[Tuple[Figure, List[Axes]]], Optional[Union[Tuple[Figure, List[Axes]], go.Figure]]]:
+    distributions: bool = True,
+    heatmap: bool = True,
+    heatmap_type: str = "static",
+    top_n: int | None = None,
+    num_cols: int = 6,
+    cmap_target_dict: dict | None = None,
+    save: str | None = None,
+) -> tuple[tuple[Figure, list[Axes]] | None, (tuple[Figure, list[Axes]] | go.Figure) | None]:
     """
     Plot the decision patterns that emerge from forest-guided clustering using
     feature distribution plots and feature heatmaps.
@@ -262,22 +262,22 @@ def plot_forest_guided_decision_paths(
     :param model_type: Type of model, either "cla" for classification or "reg" for regression. Output of `forest_guided_clustering()`.
     :type model_type: str
     :param distributions: Whether to show the feature distribution plots. Default: True.
-    :type distributions: Optional[bool]
+    :type distributions: bool
     :param heatmap: Whether to show the feature heatmap. Default: True.
-    :type heatmap: Optional[bool]
+    :type heatmap: bool
     :param heatmap_type: Heatmap shown in "static" or "interactive" style. Default: "static".
-    :type heatmap_type: Optional[str]
+    :type heatmap_type: str
     :param top_n: If specified, number of top-ranked features to plot. Default: None.
-    :type top_n: Optional[int]
-    :param num_cols: Number of columns in the subplot layout. Default: 4.
-    :type num_cols: Optional[int]
+    :type top_n: int | None
+    :param num_cols: Number of columns in the subplot layout. Default: 6.
+    :type num_cols: int
     :param cmap_target_dict: If specified, custom color map for categorical targets. Default: None.
-    :type cmap_target_dict: Optional[dict]
+    :type cmap_target_dict: dict | None
     :param save: If specified, path prefix to save plots. Default: None.
-    :type save: Optional[str]
+    :type save: str | None
 
     :return: Tuple of two optional plots. The first is always a matplotlib `fig, ax` pair, the second can be an interactive plotly Figure.
-    :rtype: Tuple[Optional[Tuple[Figure, List[Axes]]], Optional[Union[Tuple[Figure, List[Axes]], go.Figure]]]:
+    :rtype: tuple[tuple[Figure, list[Axes]] | None, (tuple[Figure, list[Axes]] | go.Figure) | None]
     """
     # select top n features and cluster, target for plotting
     if top_n:

--- a/fgclustering/forest_guided_clustering.py
+++ b/fgclustering/forest_guided_clustering.py
@@ -59,9 +59,9 @@ def forest_guided_clustering(
     :param estimator: A fitted RandomForestClassifier or RandomForestRegressor model.
     :type estimator: RandomForestClassifier | RandomForestRegressor
     :param X: Input feature matrix.
-    :type X: pandas.DataFrame
+    :type X: pd.DataFrame
     :param y: Target variable, i.e. target values or name of the target column in X.
-    :type y: str | pandas.Series
+    :type y: str | pd.Series
     :param clustering_distance_metric: An instance of DistanceRandomForestProximity.
     :type clustering_distance_metric: DistanceRandomForestProximity
     :param clustering_strategy: An instance of ClusteringKMedoids or ClusteringClara.
@@ -148,11 +148,11 @@ def forest_guided_feature_importance(
     which features are most important for distinguishing clusters, providing interpretability into the model’s decision structure.
 
     :param X: Input feature matrix.
-    :type X: pandas.DataFrame
+    :type X: pd.DataFrame
     :param y: Target variable, i.e. target values or name of the target column in X.
-    :type y: str | pandas.Series
+    :type y: str | pd.Series
     :param cluster_labels: Labels from forest-guided clustering. Output of `forest_guided_clustering()`.
-    :type cluster_labels: numpy.ndarray
+    :type cluster_labels: np.ndarray
     :param model_type: Type of model, either "cla" for classification or "reg" for regression. Output of `forest_guided_clustering()`.
     :type model_type: str
     :param feature_importance_distance_metric: Distance metric for computing feature importance ("wasserstein" or "jensenshannon"). Default: "wasserstein".
@@ -204,9 +204,9 @@ def plot_forest_guided_feature_importance(
     This function produces a series of bar plots to highlight which features drive cluster separations.
 
     :param feature_importance_local: Local importance values per cluster. Output of `plot_forest_guided_feature_importance()`.
-    :type feature_importance_local: pandas.DataFrame
+    :type feature_importance_local: pd.DataFrame
     :param feature_importance_global: Global mean importance values across clusters. Output of `plot_forest_guided_feature_importance()`.
-    :type feature_importance_global: pandas.Series
+    :type feature_importance_global: pd.Series
     :param top_n: If specified, number of top-ranked features to plot. Default: None.
     :type top_n: int | None
     :param num_cols: Number of columns in the subplot layout. Default: 4.

--- a/fgclustering/optimizer.py
+++ b/fgclustering/optimizer.py
@@ -69,9 +69,9 @@ class Optimizer:
         based on a combination of cluster stability and low impurity (classification) or low variance (regression).
 
         :param y: Target variable.
-        :type y: pandas.Series
+        :type y: pd.Series
         :param k_range: Range of k values to be evaluated (min_k, max_k).
-        :type k_range: Tuple[int]
+        :type k_range: tuple[int, int]
         :param JI_bootstrap_iter: Number of bootstrap iterations for Jaccard Index evaluation.
         :type JI_bootstrap_iter: int
         :param JI_bootstrap_sample_size: Number of samples to draw for each JI bootstrap.
@@ -86,7 +86,7 @@ class Optimizer:
         :type verbose: int
 
         :return: Tuple containing the best k, its corresponding score, Jaccard stability per cluster, and cluster labels.
-        :rtype: tuple[int, float, dict, numpy.ndarray]
+        :rtype: tuple[int, float, dict, np.ndarray]
         """
 
         self.n_samples_original = len(y)
@@ -185,7 +185,7 @@ class Optimizer:
         :param k: Number of clusters.
         :type k: int
         :param cluster_labels_original: Cluster labels of original clustering on full dataset.
-        :type cluster_labels_original: numpy.ndarray
+        :type cluster_labels_original: np.ndarray
 
         :return: Dictionary of average Jaccard Index per cluster.
         :rtype: dict
@@ -303,9 +303,9 @@ class Optimizer:
         Compute the balanced Gini impurity across clusters for classification tasks.
 
         :param categorical_values: Target labels for each sample.
-        :type categorical_values: pandas.Series
+        :type categorical_values: pd.Series
         :param cluster_labels: Cluster assignments for each sample.
-        :type cluster_labels: numpy.ndarray
+        :type cluster_labels: np.ndarray
 
         :return: Mean balanced Gini impurity across clusters.
         :rtype: float
@@ -349,9 +349,9 @@ class Optimizer:
         Compute total within-cluster variation relative to the overall variance, used for regression evaluation.
 
         :param continuous_values: Target values for each sample.
-        :type continuous_values: pandas.Series
+        :type continuous_values: pd.Series
         :param cluster_labels: Cluster assignments for each sample.
-        :type cluster_labels: numpy.ndarray
+        :type cluster_labels: np.ndarray
 
         :return: Normalized within-cluster variation score.
         :rtype: float
@@ -378,14 +378,14 @@ class Optimizer:
         Sorts clusters by the mean target value and reorders cluster labels accordingly.
 
         :param y: Target values.
-        :type y: pandas.Series
+        :type y: pd.Series
         :param cluster_labels: Labels from forest-guided clustering.
-        :type cluster_labels: numpy.ndarray
+        :type cluster_labels: np.ndarray
         :param model_type: Type of model, either "cla" for classification or "reg" for regression.
         :type model_type: str
 
         :return: New cluster labels, sorted by the target mean
-        :rtype: numpy.ndarray
+        :rtype: np.ndarray
         """
 
         # ensure y is a series

--- a/fgclustering/optimizer.py
+++ b/fgclustering/optimizer.py
@@ -276,9 +276,11 @@ class Optimizer:
                 indices_bootstrap = np.array(
                     list(mapping_cluster_labels_to_samples_bootstrap[label_bootstrap])
                 )
-                intersection = np.intersect1d(samples_original, indices_bootstrap, assume_unique=True)
-                union = np.union1d(samples_original, indices_bootstrap)
-                jaccard_matrix[i, j] = len(intersection) / len(union)
+                intersection_size = np.intersect1d(
+                    samples_original, indices_bootstrap, assume_unique=True
+                ).size
+                union_size = samples_original.size + indices_bootstrap.size - intersection_size
+                jaccard_matrix[i, j] = intersection_size / union_size
 
         # Map original cluster to best Jaccard index using greedy assignment
         JI_per_cluster = {label: 0.0 for label in clusters_original}

--- a/fgclustering/optimizer.py
+++ b/fgclustering/optimizer.py
@@ -9,7 +9,6 @@ import pandas as pd
 from tqdm import tqdm
 from joblib import Parallel, delayed
 from collections import defaultdict, Counter
-from typing import Union, Tuple, Optional
 
 from .utils import map_clusters_to_samples
 from .distance import DistanceRandomForestProximity
@@ -36,7 +35,7 @@ class Optimizer:
     :param distance_metric: An instance of DistanceRandomForestProximity.
     :type distance_metric: DistanceRandomForestProximity
     :param clustering_strategy: An instance of ClusteringKMedoids or ClusteringClara.
-    :type clustering_strategy: Union[ClusteringKMedoids, ClusteringClara]
+    :type clustering_strategy: ClusteringKMedoids | ClusteringClara
     :param random_state: Random seed for reproducibility.
     :type random_state: int
     """
@@ -44,7 +43,7 @@ class Optimizer:
     def __init__(
         self,
         distance_metric: DistanceRandomForestProximity,
-        clustering_strategy: Union[ClusteringKMedoids, ClusteringClara],
+        clustering_strategy: ClusteringKMedoids | ClusteringClara,
         random_state: int,
     ):
         """Constructor for the Optimizer class."""
@@ -55,14 +54,14 @@ class Optimizer:
     def optimizeK(
         self,
         y: pd.Series,
-        k_range: Tuple[int],
+        k_range: tuple[int, int],
         JI_bootstrap_iter: int,
-        JI_bootstrap_sample_size: Union[int, float],
+        JI_bootstrap_sample_size: int | float,
         JI_discart_value: float,
         model_type: str,
         n_jobs: int,
         verbose: int,
-    ) -> Tuple[int, float, dict, np.ndarray]:
+    ) -> tuple[int, float, dict, np.ndarray]:
         """
         Search for the optimal number of clusters within a specified range using clustering quality and stability metrics.
 
@@ -70,13 +69,13 @@ class Optimizer:
         based on a combination of cluster stability and low impurity (classification) or low variance (regression).
 
         :param y: Target variable.
-        :type y: Union[str, pandas.Series]
+        :type y: pandas.Series
         :param k_range: Range of k values to be evaluated (min_k, max_k).
         :type k_range: Tuple[int]
         :param JI_bootstrap_iter: Number of bootstrap iterations for Jaccard Index evaluation.
         :type JI_bootstrap_iter: int
         :param JI_bootstrap_sample_size: Number of samples to draw for each JI bootstrap.
-        :type JI_bootstrap_sample_size: Union[int, float]
+        :type JI_bootstrap_sample_size: int | float
         :param JI_discart_value: Jaccard Index threshold to discard unstable clusters.
         :type JI_discart_value: float
         :param model_type: Type of model, either "cla" for classification or "reg" for regression.
@@ -87,7 +86,7 @@ class Optimizer:
         :type verbose: int
 
         :return: Tuple containing the best k, its corresponding score, Jaccard stability per cluster, and cluster labels.
-        :rtype: Tuple[int, float, dict, numpy.ndarray]
+        :rtype: tuple[int, float, dict, numpy.ndarray]
         """
 
         self.n_samples_original = len(y)
@@ -170,11 +169,9 @@ class Optimizer:
 
         # reorder cluster labels by target mean
         reordered_cluster_labels = self._sort_clusters_by_target(
-            y=y, 
-            cluster_labels=cluster_labels,
-            model_type=model_type
-            )
-        
+            y=y, cluster_labels=cluster_labels, model_type=model_type
+        )
+
         return k, cluster_score, cluster_stability, reordered_cluster_labels
 
     def _compute_JI(
@@ -377,14 +374,14 @@ class Optimizer:
     ) -> np.ndarray:
         """
         Sorts clusters by the mean target value and reorders cluster labels accordingly.
-        
+
         :param y: Target values.
         :type y: pandas.Series
         :param cluster_labels: Labels from forest-guided clustering.
         :type cluster_labels: numpy.ndarray
         :param model_type: Type of model, either "cla" for classification or "reg" for regression.
         :type model_type: str
-    
+
         :return: New cluster labels, sorted by the target mean
         :rtype: numpy.ndarray
         """
@@ -395,23 +392,21 @@ class Optimizer:
 
         # use category codes for classification
         target = y.astype("category").cat.codes if model_type == "cla" else y
-    
-        df = pd.DataFrame({
-            "cluster": cluster_labels,
-            "target": target
-        })
-        
+
+        df = pd.DataFrame({"cluster": cluster_labels, "target": target})
+
         # get the mean target for each cluster
         mean_per_cluster = df.groupby("cluster")["target"].mean()
-    
+
         # get the original cluster labels, sorted by their mean target
         sorted_clusters = mean_per_cluster.sort_values().index
-    
+
         # create mapping from the old cluster labels to the new, ranked labels
-        cluster_mapping = {old_label: new_label for new_label, old_label in enumerate(sorted_clusters, start=1)}
-    
+        cluster_mapping = {
+            old_label: new_label for new_label, old_label in enumerate(sorted_clusters, start=1)
+        }
+
         # apply the re-labeling
         new_labels = pd.Series(cluster_labels).map(cluster_mapping)
-    
-        return new_labels.to_numpy()
 
+        return new_labels.to_numpy()

--- a/fgclustering/plotting.py
+++ b/fgclustering/plotting.py
@@ -36,9 +36,9 @@ def plot_feature_importance(
     Visualize global and local feature importance values as bar charts.
 
     :param feature_importance_local: Local importance values per cluster.
-    :type feature_importance_local: pandas.DataFrame
+    :type feature_importance_local: pd.DataFrame
     :param feature_importance_global: Global mean importance values across clusters.
-    :type feature_importance_global: pandas.Series
+    :type feature_importance_global: pd.Series
     :param top_n: If specified, number of top-ranked features to plot.
     :type top_n: int
     :param num_cols: Number of columns in the subplot layout.
@@ -486,10 +486,10 @@ def _process_features_for_heatmap(
     Convert categorical features to numeric codes and normalize all features using MinMax scaling.
 
     :param features: DataFrame containing the features to be encoded and scaled.
-    :type features: pandas.DataFrame
+    :type features: pd.DataFrame
 
     :return: Transformed and normalized features.
-    :rtype: pandas.DataFrame
+    :rtype: pd.DataFrame
     """
 
     # Encode categorical features as numeric
@@ -514,7 +514,7 @@ def _get_heatmap_plotting_settings(
     Define color schemes, boundary widths, and titles for heatmap plotting.
 
     :param target: Target variable.
-    :type target: pandas.DataFrame
+    :type target: pd.DataFrame
     :param top_n: If specified, number of top-ranked features to display in the title.
     :type top_n: int
 
@@ -567,11 +567,11 @@ def _plot_heatmaps_static(
     Create a static (matplotlib) heatmap of target and feature values with visual cluster boundaries.
 
     :param target: Target variable.
-    :type target: pandas.DataFrame
+    :type target: pd.DataFrame
     :param target_cmap: Colormap used for the target heatmap.
     :type target_cmap: ListedColormap
     :param features: Normalized feature matrix.
-    :type features: pandas.DataFrame
+    :type features: pd.DataFrame
     :param features_color: Colormap used for the feature heatmap.
     :type features_color: str
     :param boundaries_color: Color used for the dividers in the feature heatmap.
@@ -660,7 +660,7 @@ def _plot_heatmaps_interactive(
     Create an interactive (Plotly) heatmap of target and feature values with visual cluster boundaries.
 
     :param target: Target variable.
-    :type target: pandas.DataFrame
+    :type target: pd.DataFrame
     :param target_colorscale: Color scale used for the target heatmap.
     :type target_colorscale: list
     :param target_colorbar: Color bar used for the target heatmap.
@@ -668,7 +668,7 @@ def _plot_heatmaps_interactive(
     :param target_showscale: Whether to display the color scale for the target heatmap.
     :type target_showscale: bool
     :param features: Normalized feature matrix.
-    :type features: pandas.DataFrame
+    :type features: pd.DataFrame
     :param features_color: Colormap used for the feature heatmap.
     :type features_color: str
     :param title: Title of the heatmap figure.

--- a/fgclustering/plotting.py
+++ b/fgclustering/plotting.py
@@ -13,7 +13,6 @@ from matplotlib.axes import Axes
 from matplotlib import rc_context
 from matplotlib.colors import ListedColormap, to_rgba
 from plotly.subplots import make_subplots
-from typing import Tuple, List, Union
 from pathlib import Path
 from sklearn.preprocessing import MinMaxScaler, LabelEncoder
 
@@ -32,7 +31,7 @@ def plot_feature_importance(
     save: str,
     reorder: bool = False,
     recolor: bool = False,
-) -> Tuple[Figure, List[Axes]]:
+) -> tuple[Figure, list[Axes]]:
     """
     Visualize global and local feature importance values as bar charts.
 
@@ -45,14 +44,14 @@ def plot_feature_importance(
     :param num_cols: Number of columns in the subplot layout.
     :type num_cols: int
     :param save: If specified, path prefix to save plots.
-    :type save: int
-    :param reorder: If True, reorder the local importance values to match the global importance order.
+    :type save: str
+    :param reorder: If True, reorder the local importance values to match the global importance order. Default: False.
     :type reorder: bool
-    :param recolor: If True, recolor the bars based on the global importance order.
+    :param recolor: If True, recolor the bars based on the global importance order. Default: False.
     :type recolor: bool
 
     :return: Matplotlib figure and axes with bar charts of global and local feature importance values.
-    :rtype: Tuple[Figure, List[Axes]]
+    :rtype: tuple[Figure, list[Axes]]
     """
     # Determine figure size dynamically based on the number of features
     num_features_GFI = len(feature_importance_global.index)
@@ -78,10 +77,18 @@ def plot_feature_importance(
                 "Importance": feature_importance_global.to_list(),
             }
         ).sort_values(by="Importance", ascending=False)
-        kwargs = dict(color="#3470a3") if not recolor else dict(
-            hue="Feature",
-            palette=dict(zip(importance_global["Feature"].to_list(),
-                             sns.color_palette("tab20", n_colors=len(importance_global)))),
+        kwargs = (
+            dict(color="#3470a3")
+            if not recolor
+            else dict(
+                hue="Feature",
+                palette=dict(
+                    zip(
+                        importance_global["Feature"].to_list(),
+                        sns.color_palette("tab20", n_colors=len(importance_global)),
+                    )
+                ),
+            )
         )
         if top_n:
             importance_global = importance_global.iloc[:top_n,]
@@ -96,9 +103,7 @@ def plot_feature_importance(
             if reorder:
                 # do not sort - use the global importance order instead
                 importance_local = (
-                    feature_importance_local[[cluster]]
-                    .iloc[importance_global.index]
-                    .reset_index()
+                    feature_importance_local[[cluster]].iloc[importance_global.index].reset_index()
                 )
                 importance_local.columns = ["Feature", "Importance"]
             else:
@@ -129,7 +134,7 @@ def plot_distributions(
     num_cols: int,
     cmap_target_dict: dict,
     save: str,
-) -> Tuple[Figure, List[Axes]]:
+) -> tuple[Figure, list[Axes]]:
     """
     Plot the decision patterns that emerge from forest-guided clustering using feature distribution plots.
 
@@ -145,7 +150,7 @@ def plot_distributions(
     :type save: str
 
     :return: Feature distribution plots as matplotlib figure and axes.
-    :rtype: Tuple[Figure, List[Axes]]
+    :rtype: tuple[Figure, list[Axes]]
     """
 
     features_to_plot = data_clustering_ranked.drop("cluster", axis=1, inplace=False).columns.to_list()
@@ -184,8 +189,11 @@ def plot_distributions(
                 ax.legend(bbox_to_anchor=(1, 1), loc=2, fontsize="x-small")
             else:
                 # Plot categorical features as stacked barplots
-                count_df = data_clustering_ranked.groupby(
-                    ["cluster", feature], observed=False).size().unstack(fill_value=0)
+                count_df = (
+                    data_clustering_ranked.groupby(["cluster", feature], observed=False)
+                    .size()
+                    .unstack(fill_value=0)
+                )
 
                 # Get top 10 most frequent categories
                 top_categories = count_df.sum().nlargest(10).index
@@ -252,7 +260,7 @@ def plot_heatmap_classification(
     heatmap_type: str,
     cmap_target_dict: dict,
     save: str,
-) -> Union[Tuple[Figure, List[Axes]], go.Figure]:
+) -> tuple[Figure, list[Axes]] | go.Figure:
     """
     Plot the decision patterns that emerge from forest-guided clustering using feature heatmaps for classification tasks.
 
@@ -268,7 +276,7 @@ def plot_heatmap_classification(
     :type save: str
 
     :return: Either static matplotlib figure and axes or interactive plotly figure.
-    :rtype: Union[Tuple[Figure, List[Axes]], go.Figure]
+    :rtype: tuple[Figure, list[Axes]] | go.Figure
     """
     cluster_labels = data_clustering_ranked["cluster"]
 
@@ -316,7 +324,9 @@ def plot_heatmap_classification(
 
         # Add a custom legend or color bar for targets plot
         handles = [
-            plt.Line2D([0], [0], marker="o", color="w", markerfacecolor=target_legend_color_map[i], markersize=10)
+            plt.Line2D(
+                [0], [0], marker="o", color="w", markerfacecolor=target_legend_color_map[i], markersize=10
+            )
             for i in range(len(categories))
         ]
         ax_features.legend(
@@ -348,7 +358,9 @@ def plot_heatmap_classification(
             ]
 
         target_legend_color_map = {i: target_color_palette_rgb[i] for i in range(len(categories))}
-        target_colorscale = [[i / (len(categories) - 1), target_legend_color_map[i]] for i in range(len(categories))]
+        target_colorscale = [
+            [i / (len(categories) - 1), target_legend_color_map[i]] for i in range(len(categories))
+        ]
 
         fig = _plot_heatmaps_interactive(
             target,
@@ -381,12 +393,13 @@ def plot_heatmap_classification(
     else:
         raise ValueError(f'`heatmap_type` must be either "static" or "interactive"')
 
+
 def plot_heatmap_regression(
     data_clustering_ranked: pd.DataFrame,
     top_n: int,
     heatmap_type: str,
     save: str,
-) -> Union[Tuple[Figure, List[Axes]], go.Figure]:
+) -> tuple[Figure, list[Axes]] | go.Figure:
     """
     Plot the decision patterns that emerge from forest-guided clustering using feature heatmaps for regression tasks.
 
@@ -400,7 +413,7 @@ def plot_heatmap_regression(
     :type save: str
 
     :return: Either static matplotlib figure and axes or interactive plotly figure.
-    :rtype: Union[Tuple[Figure, List[Axes]], go.Figure]
+    :rtype: tuple[Figure, list[Axes]] | go.Figure
     """
     cluster_labels = data_clustering_ranked["cluster"]
 
@@ -442,7 +455,7 @@ def plot_heatmap_regression(
 
         plt.tight_layout()
         if save:
-            save_figure(save, '_heatmap')
+            save_figure(save, "_heatmap")
         return fig, [ax_target, ax_target_cb, ax_features, ax_features_cb, target_plot, feature_plot]
 
     elif heatmap_type == "interactive":
@@ -464,6 +477,7 @@ def plot_heatmap_regression(
         return fig
     else:
         raise ValueError(f'`heatmap_type` must be either "static" or "interactive"')
+
 
 def _process_features_for_heatmap(
     features: pd.DataFrame,
@@ -495,7 +509,7 @@ def _process_features_for_heatmap(
 def _get_heatmap_plotting_settings(
     target: pd.DataFrame,
     top_n: int,
-) -> Tuple[str, str, str, int, str]:
+) -> tuple[str, str, str, int, str]:
     """
     Define color schemes, boundary widths, and titles for heatmap plotting.
 
@@ -505,7 +519,7 @@ def _get_heatmap_plotting_settings(
     :type top_n: int
 
     :return: Tuple with color settings, boundary width, and heatmap title.
-    :rtype: Tuple[str, str, str, int, str]
+    :rtype: tuple[str, str, str, int, str]
     """
 
     color_target = "Greens"
@@ -520,19 +534,23 @@ def _get_heatmap_plotting_settings(
 
 
 def _insert_boundaries(
-        df: pd.DataFrame,
-        boundaries: np.ndarray,
-        boundaries_width: int,
+    df: pd.DataFrame,
+    boundaries: np.ndarray,
+    boundaries_width: int,
 ) -> pd.DataFrame:
     add = 0
     for boundary in boundaries:
-        df = pd.concat([
-            df.iloc[:, :boundary + add],  # until the boundary
-            pd.DataFrame(  # the NA block
-                np.full((df.shape[0], boundaries_width), pd.NA),
-                index=df.index, ),
-            df.iloc[:, boundary + add:]  # from the boundary
-        ], axis=1)
+        df = pd.concat(
+            [
+                df.iloc[:, : boundary + add],  # until the boundary
+                pd.DataFrame(  # the NA block
+                    np.full((df.shape[0], boundaries_width), pd.NA),
+                    index=df.index,
+                ),
+                df.iloc[:, boundary + add :],  # from the boundary
+            ],
+            axis=1,
+        )
         add += boundaries_width
     return df
 
@@ -544,7 +562,7 @@ def _plot_heatmaps_static(
     features_color: str,
     boundaries_color: str,
     title: str,
-) -> Tuple[Figure, Axes, Axes, Axes, Axes, Axes, Axes]:
+) -> tuple[Figure, Axes, Axes, Axes, Axes, Axes, Axes]:
     """
     Create a static (matplotlib) heatmap of target and feature values with visual cluster boundaries.
 
@@ -562,7 +580,7 @@ def _plot_heatmaps_static(
     :type title: str
 
     :return: Tuple of figure and axes objects for both heatmaps and colorbars.
-    :rtype: Tuple[Figure, Axes, Axes, Axes, Axes, Axes, Axes]
+    :rtype: tuple[Figure, Axes, Axes, Axes, Axes, Axes, Axes]
     """
 
     # Set up the figure and subplots
@@ -672,9 +690,7 @@ def _plot_heatmaps_interactive(
             showscale=target_showscale,  # Hide color bar for the target
             hoverongaps=False,
             customdata=np.tile(np.array(features.columns, dtype=str), target.shape),
-            hovertemplate="<b>Sample: %{customdata}</b><br>" +
-                          "x: %{x}<br>" +
-                          "target: %{z}<extra></extra>",
+            hovertemplate="<b>Sample: %{customdata}</b><br>" + "x: %{x}<br>" + "target: %{z}<extra></extra>",
         ),
         row=1,
         col=1,
@@ -693,10 +709,10 @@ def _plot_heatmaps_interactive(
             showscale=True,
             hoverongaps=False,
             customdata=np.tile(np.array(features.columns, dtype=str), (features.shape[0], 1)),
-            hovertemplate="<b>Sample: %{customdata}</b><br>" +
-                          "x: %{x}<br>" +
-                          "y: %{y}<br>" +
-                          "value: %{z}<extra></extra>",
+            hovertemplate="<b>Sample: %{customdata}</b><br>"
+            + "x: %{x}<br>"
+            + "y: %{y}<br>"
+            + "value: %{z}<extra></extra>",
         ),
         row=2,
         col=1,
@@ -720,8 +736,11 @@ def _plot_heatmaps_interactive(
     )
     # make sure ALL row labels are shown
     row_labels = ["target"] + list(features.index.astype(str))
-    fig.update_yaxes(type="category", tickmode="array",
-                     ticktext=row_labels, tickvals=row_labels,
-                     )
+    fig.update_yaxes(
+        type="category",
+        tickmode="array",
+        ticktext=row_labels,
+        tickvals=row_labels,
+    )
 
     return fig

--- a/fgclustering/statistics.py
+++ b/fgclustering/statistics.py
@@ -46,18 +46,18 @@ class FeatureImportance:
         Computes feature importance scores for clustered data using a selected distance metric.
 
         :param X: Input feature matrix.
-        :type X: pandas.DataFrame
+        :type X: pd.DataFrame
         :param y: Target variable.
-        :type y: pandas.Series
+        :type y: pd.Series
         :param cluster_labels: Labels from forest-guided clustering.
-        :type cluster_labels: numpy.ndarray
+        :type cluster_labels: np.ndarray
         :param model_type: Type of model, either "cla" for classification or "reg" for regression.
         :type model_type: str
         :param verbose: Verbosity level (0 = silent, 1 = progress messages).
         :type verbose: int
 
         :return: Tuple containing local feature importance scores, global feature importance scores, and the clustering data ordered by the global feature importance.
-        :rtype: tuple[pandas.DataFrame, pandas.Series, pandas.DataFrame]
+        :rtype: tuple[pd.DataFrame, pd.Series, pd.DataFrame]
         """
         self.verbose = verbose
 
@@ -90,12 +90,12 @@ class FeatureImportance:
         Calculates the distance of each feature between clusters and background.
 
         :param X: Input feature matrix.
-        :type X: pandas.DataFrame
+        :type X: pd.DataFrame
         :param cluster_labels: Labels from forest-guided clustering.
-        :type cluster_labels: numpy.ndarray
+        :type cluster_labels: np.ndarray
 
         :return: A DataFrame of local feature importance scores.
-        :rtype: pandas.DataFrame
+        :rtype: pd.DataFrame
         """
         clusters_unique = np.unique(cluster_labels)
         distances = pd.DataFrame(index=X.columns, columns=clusters_unique)

--- a/fgclustering/statistics.py
+++ b/fgclustering/statistics.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from tqdm import tqdm
-from pandas.api.types import is_numeric_dtype
+from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 from .distance import DistanceJensenShannon, DistanceWasserstein
 
@@ -119,6 +119,7 @@ class FeatureImportance:
             # Check feature type
             if (
                 isinstance(values_background.dtype, pd.CategoricalDtype)
+                or is_string_dtype(values_background)
                 or values_background.dtype == "object"
                 or values_background.dtype == "bool"
             ):

--- a/fgclustering/statistics.py
+++ b/fgclustering/statistics.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 
 from tqdm import tqdm
-from typing import Union, Tuple
 from pandas.api.types import is_numeric_dtype
 
 from .distance import DistanceJensenShannon, DistanceWasserstein
@@ -25,12 +24,12 @@ class FeatureImportance:
     distribution of feature values within clusters against the background (entire dataset).
 
     :param distance_metric: An instance of DistanceJensenShannon or DistanceWasserstein.
-    :type distance_metric: Union[DistanceJensenShannon, DistanceWasserstein]
+    :type distance_metric: DistanceJensenShannon | DistanceWasserstein
     """
 
     def __init__(
         self,
-        distance_metric: Union[DistanceJensenShannon, DistanceWasserstein],
+        distance_metric: DistanceJensenShannon | DistanceWasserstein,
     ):
         """Constructor for the FeatureImportance class."""
         self.distance_metric = distance_metric
@@ -42,7 +41,7 @@ class FeatureImportance:
         cluster_labels: np.ndarray,
         model_type: str,
         verbose: int,
-    ) -> Tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame]:
         """
         Computes feature importance scores for clustered data using a selected distance metric.
 
@@ -58,7 +57,7 @@ class FeatureImportance:
         :type verbose: int
 
         :return: Tuple containing local feature importance scores, global feature importance scores, and the clustering data ordered by the global feature importance.
-        :rtype: Tuple[pandas.DataFrame, pandas.Series, pandas.DataFrame]
+        :rtype: tuple[pandas.DataFrame, pandas.Series, pandas.DataFrame]
         """
         self.verbose = verbose
 

--- a/fgclustering/utils.py
+++ b/fgclustering/utils.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Any
 
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.base import ClassifierMixin, RegressorMixin
 
 ############################################
 # Utility Functions
@@ -58,16 +58,12 @@ def check_input_estimator(
     :return: Tuple indicating whether the estimator is valid and its model type ('cla' or 'reg').
     :rtype: tuple[bool, str]
     """
-    valid_estimator = False
-    model_type = "invalid"
-    if isinstance(estimator, RandomForestClassifier):
-        valid_estimator = True
-        model_type = "cla"
-    elif isinstance(estimator, RandomForestRegressor):
-        valid_estimator = True
-        model_type = "reg"
-
-    return valid_estimator, model_type
+    if isinstance(estimator, ClassifierMixin):
+        return True, "cla"
+    elif isinstance(estimator, RegressorMixin):
+        return True, "reg"
+    else:
+        return False, "invalid"
 
 
 def matplotlib_to_plotly(

--- a/fgclustering/utils.py
+++ b/fgclustering/utils.py
@@ -81,6 +81,8 @@ def matplotlib_to_plotly(
     :return: List of Plotly-compatible color mappings.
     :rtype: list
     """
+    if pl_entries < 2:
+        raise ValueError(f"pl_entries must be >= 2, got {pl_entries}")
     cmap = matplotlib.colormaps.get_cmap(cmap_name)
     h = np.linspace(0, 1, pl_entries)
     colors = cmap(h)[:, :3]

--- a/fgclustering/utils.py
+++ b/fgclustering/utils.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 from pathlib import Path
 from collections import defaultdict
-from typing import Union, Tuple, Any, Optional
+from typing import Any
 
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
@@ -23,18 +23,18 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 def check_input_data(
     X: pd.DataFrame,
-    y: Union[str, pd.Series],
-) -> Tuple[pd.DataFrame, pd.Series]:
+    y: str | pd.Series,
+) -> tuple[pd.DataFrame, pd.Series]:
     """
     Splits the input into features and target. If `y` is a string, it's interpreted as the name of the target column in `X`.
 
     :param X: Input features as a DataFrame or array-like object.
     :type X: pandas.DataFrame
     :param y: Target values or name of the target column.
-    :type y: Union[str, pandas.Series]
+    :type y: str | pandas.Series
 
     :return: Tuple of feature DataFrame and target Series.
-    :rtype: Tuple[pd.DataFrame, pd.Series]
+    :rtype: tuple[pd.DataFrame, pd.Series]
     """
     if isinstance(y, str):
         y_data = pd.Series(X[y]).reset_index(drop=True)
@@ -48,7 +48,7 @@ def check_input_data(
 
 def check_input_estimator(
     estimator: Any,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """
     Checks whether the given estimator is a supported RandomForest model and determines its type.
 
@@ -56,7 +56,7 @@ def check_input_estimator(
     :type estimator: Any
 
     :return: Tuple indicating whether the estimator is valid and its model type ('cla' or 'reg').
-    :rtype: Tuple[bool, str]
+    :rtype: tuple[bool, str]
     """
     valid_estimator = False
     model_type = "invalid"
@@ -72,15 +72,15 @@ def check_input_estimator(
 
 def matplotlib_to_plotly(
     cmap_name: str,
-    pl_entries: Optional[int] = 255,
+    pl_entries: int = 255,
 ) -> list:
     """
     Converts a matplotlib colormap to a Plotly-compatible colorscale.
 
     :param cmap_name: Name of the matplotlib colormap to convert.
     :type cmap_name: str
-    :param pl_entries: Number of color entries to generate.
-    :type pl_entries: Optional[int]
+    :param pl_entries: Number of color entries to generate. Default: 255.
+    :type pl_entries: int
 
     :return: List of Plotly-compatible color mappings.
     :rtype: list
@@ -105,7 +105,7 @@ def save_figure(
 
     :param filename_base: Base file path as str, including desired extension.
     :type filename_base: str
-    :param filename_extra: String to append to the filename stem before the extension, empty by default.
+    :param filename_extra: String to append to the filename stem before the extension. Default: "".
     :type filename_extra: str
 
     :return: None
@@ -114,8 +114,8 @@ def save_figure(
     p = Path(filename_base)
     p.parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(
-        p.parent / f"{p.stem}{filename_extra}{p.suffix}", 
-        bbox_inches="tight", 
+        p.parent / f"{p.stem}{filename_extra}{p.suffix}",
+        bbox_inches="tight",
         dpi=300,
     )
 
@@ -141,15 +141,15 @@ def check_disk_space(
 
 def map_clusters_to_samples(
     labels: np.ndarray,
-    samples_mapping: Optional[np.ndarray] = None,
+    samples_mapping: np.ndarray | None = None,
 ) -> dict:
     """
     Maps sample indices to their corresponding cluster labels.
 
     :param labels: Cluster label for each sample.
     :type labels: np.ndarray
-    :param samples_mapping: Optional mapping of internal to external indices.
-    :type samples_mapping: Optional[np.ndarray]
+    :param samples_mapping: Optional mapping of internal to external indices. Default: None.
+    :type samples_mapping: np.ndarray | None
 
     :return: Dictionary mapping cluster labels to sets of sample indices.
     :rtype: dict
@@ -165,16 +165,16 @@ def map_clusters_to_samples(
 
 
 def check_k_range(
-    k: Union[int, Tuple[int, int], None],
-) -> Tuple[int, int]:
+    k: int | tuple[int, int] | None,
+) -> tuple[int, int]:
     """
     Validates and returns a standardized k range for clustering.
 
     :param k: Number of clusters or range of cluster values.
-    :type k: Union[int, Tuple[int, int], None]
+    :type k: int | tuple[int, int] | None
 
     :return: Tuple representing the range of k values.
-    :rtype: Tuple[int, int]
+    :rtype: tuple[int, int]
     """
     if k is None:
         k_range = (2, 6)
@@ -191,7 +191,7 @@ def check_k_range(
 
 
 def check_sub_sample_size(
-    sub_sample_size: Union[int, float, None],
+    sub_sample_size: int | float | None,
     n_samples: int,
     application: str,
     verbose: int,
@@ -200,7 +200,7 @@ def check_sub_sample_size(
     Validates and computes the number of samples to use in a subsample.
 
     :param sub_sample_size: Fraction (float), fixed count (int), or None for auto.
-    :type sub_sample_size: float, int, or None
+    :type sub_sample_size: int | float | None
     :param n_samples: Total number of samples available.
     :type n_samples: int
     :param application: Name of the application for logging purposes.

--- a/fgclustering/utils.py
+++ b/fgclustering/utils.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Any
 
-from sklearn.base import ClassifierMixin, RegressorMixin
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 ############################################
 # Utility Functions
@@ -29,9 +29,9 @@ def check_input_data(
     Splits the input into features and target. If `y` is a string, it's interpreted as the name of the target column in `X`.
 
     :param X: Input features as a DataFrame or array-like object.
-    :type X: pandas.DataFrame
+    :type X: pd.DataFrame
     :param y: Target values or name of the target column.
-    :type y: str | pandas.Series
+    :type y: str | pd.Series
 
     :return: Tuple of feature DataFrame and target Series.
     :rtype: tuple[pd.DataFrame, pd.Series]
@@ -58,9 +58,9 @@ def check_input_estimator(
     :return: Tuple indicating whether the estimator is valid and its model type ('cla' or 'reg').
     :rtype: tuple[bool, str]
     """
-    if isinstance(estimator, ClassifierMixin):
+    if isinstance(estimator, RandomForestClassifier):
         return True, "cla"
-    elif isinstance(estimator, RegressorMixin):
+    elif isinstance(estimator, RandomForestRegressor):
         return True, "reg"
     else:
         return False, "invalid"

--- a/publication/profiling_runtime_memory/profiling.py
+++ b/publication/profiling_runtime_memory/profiling.py
@@ -1,12 +1,10 @@
 import os
 import gc
 import time
-import kmedoids
 import argparse
 import numpy as np
 import pandas as pd
 
-from numba import njit, prange
 from memory_profiler import memory_usage
 
 from sklearn.datasets import make_classification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["fgclustering"]
@@ -13,43 +14,56 @@ write_to = "fgclustering/_version.py"
 [project]
 name = "fgclustering"
 dynamic = ["version"]
+description = "Forest-Guided Clustering: Explainability method for Random Forest models."
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+license = { file = "LICENSE" }
 authors = [
   { name = "Lisa Barros de Andrade e Sousa", email = "lisa.barros.andrade.sousa@gmail.com" },
   { name = "Dominik Thalmeier" },
-  { name = "Helena Pelin" },
+  { name = "Helena Pelin", email = "helena.pelin@helmholtz-muenchen.de" },
   { name = "Marie Piraud", email = "marie.piraud@helmholtz-muenchen.de" },
 ]
 maintainers = [
   { name = "Lisa Barros de Andrade e Sousa", email = "lisa.barros.andrade.sousa@gmail.com" },
 ]
-description = "Forest-Guided Clustering - Explainability method for Random Forest models."
-keywords = ["random forest", "xai", "explainable ai"]
-readme = "README.md"
-requires-python = ">=3.7"
+keywords = [
+  "random forest",
+  "xai",
+  "explainable ai",
+  "forest-guided clustering",
+]
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+
 dependencies = [
-  "pandas",
-  "numpy",
-  "matplotlib",
+  "numpy>=1.23",
+  "pandas>=1.5",
+  "matplotlib>=3.6",
   "seaborn>=0.12",
-  "scikit-learn",
-  "kmedoids",
-  "scipy",
-  "tqdm",
+  "scikit-learn>=1.2",
+  "scipy>=1.9",
+  "numba>=0.57",
+  "tqdm>=4.65",
+  "kmedoids>=0.4",
   "statsmodels>=0.13.5",
   "numexpr>=2.8.4",
-  "numba",
-  "imblearn",
-  "plotly",
-  "nbformat",
+  "imbalanced-learn>=0.11",
+  "plotly>=5.15",
+  "nbformat>=5.7",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest>=7", "pytest-cov", "ruff", "black", "mypy"]
 
 [project.urls]
 documentation = "https://forest-guided-clustering.readthedocs.io/en/latest/"


### PR DESCRIPTION
## Summary

Updates typing and docstrings to current Python standards, adds support for string (categorical) features in feature importance, and applies two performance optimizations.

## 1. Type hints and docstrings

- **Annotations:** Replaced `Union[A, B]` with `A | B`, `Optional[X]` with `X | None` (or the concrete type when the default is not `None`). Replaced `Tuple`/`List` from `typing` with built-in `tuple`/`list`. Applied in `clustering.py`, `plotting.py`, `utils.py`, `statistics.py`, `forest_guided_clustering.py`, `distance.py`, `optimizer.py`. Unused typing imports removed.
- **Docstrings:** All `:type` and `:rtype` use the same style (e.g. `tuple[...]`, `X | None`). Defaults documented consistently (e.g. `num_cols` default 6 in `plot_forest_guided_decision_paths`, `reorder`/`recolor` Default: False, `pl_entries` Default: 255). Corrected `:type save:` from `int` to `str` in `plot_feature_importance`.
- **Unified numpy/pandas in docstrings:** All docstring type references use `pd.DataFrame`, `pd.Series`, `np.ndarray`, `np.memmap` (replacing `pandas.DataFrame`, `pandas.Series`, `numpy.ndarray`, `numpy.memmap`) so they match the parameter annotations.

## 2. String dtype as categorical (feature importance)

- **Issue:** Columns with pandas string dtype (`dtype="string"` / `StringDtype`) were not treated as categorical and raised "type … is not supported" in `FeatureImportance._calculate_cluster_distance`.
- **Change:** In `statistics.py`, added `is_string_dtype(values_background)` to the condition that sets `is_categorical = True` (alongside `CategoricalDtype`, `object`, `bool`). String columns are now handled as categorical in distance-based feature importance.

## 3. Distance matrix: symmetric fill without extra allocation

- **Before:** Only the upper triangle was filled in the numba kernel; symmetry was enforced with `distance_matrix += distance_matrix.T`, which can allocate a temporary full n×n array.
- **After:** The numba loop in `_calculate_distances` (in `distance.py`) writes both `distance_matrix[i, j]` and `distance_matrix[j, i]`. The transpose step is removed. Docstring updated to describe symmetric fill.

## 4. Jaccard index without `np.union1d`

- **Before:** In `optimizer._compute_JI_single_bootstrap`, Jaccard was computed as `len(np.intersect1d(...)) / len(np.union1d(...))`, allocating a union array per pair.
- **After:** Use `intersection_size = np.intersect1d(..., assume_unique=True).size` and `union_size = len(a) + len(b) - intersection_size`, then `intersection_size / union_size`. Same result, no union array allocation in the bootstrap loop.

## 5. Python support, project config, and CI

- **Python support (pyproject.toml):** `requires-python` set to `>=3.10,<3.14`, so the package officially supports Python 3.10, 3.11, 3.12, and 3.13. Classifiers and dependency bounds updated accordingly. This aligns with the modern typing used in the codebase (PEP 604, PEP 585).
- **CITATION.cff:** Citation metadata added/updated (CFF 1.2.0): title, authors, DOI (arXiv), repository and documentation URLs, abstract, keywords, and MIT license. Enables proper citation when the software is used in research.
- **GitHub workflows:**  
  - **test.yml:** Runs on push and pull_request to `main` (with paths-ignore for README, docs, tutorials). A dedicated job parses supported Python versions from `pyproject.toml` via `.github/scripts/ci_python_versions.py` and outputs a JSON matrix; the test job then runs pytest on Ubuntu, macOS, and Windows for each of those versions (Conda-based install). Keeps CI in sync with `requires-python` without hardcoding versions in the workflow.  
  - **release.yml:** Triggers on release creation/publishing or manual dispatch; runs the test workflow first, then builds the package and publishes to PyPI with twine.
- **.github/scripts/ci_python_versions.py:** Reads `requires-python` from `pyproject.toml` (e.g. `>=3.10,<3.14`), parses the range, and prints a JSON list of versions (e.g. `["3.10","3.11","3.12","3.13"]`) for use as the test matrix in GitHub Actions.