### PR TITLE
40-max_depth_for_proximity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Numba kernel `_calculate_lca_distances` for the LCA distance computation.
 - `fgclustering` package now exports `DistanceRandomForestLCA` (added to `__all__`).
 - `CHANGELOG.md` (this file).
+- `DistanceRandomForestProximity.max_depth_for_proximity` parameter: collapses each
+  leaf to the nearest ancestor whose tree depth is at most the given threshold,
+  capping the granularity of the proximity-induced partition. `0` collapses every
+  sample to the root; large values asymptote to standard terminal-node proximity.
+  Defaults to `None`.
+- Cross-PR infrastructure note: this parameter reuses `_compute_node_depths`
+  introduced in PR 2 and `_compute_parent_array` / `_build_leaf_to_ancestor_map` /
+  `DistanceRandomForestProximity._collapse_terminals` /
+  `_validate_mutually_exclusive` introduced in PR 1.
 
 ### Changed
 - `DistanceRandomForestProximity.__init__` now accepts `min_samples_in_node` and
@@ -49,6 +58,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   include `DistanceRandomForestLCA`, and added it to `__all__`. No removals.
 - Class and method docstrings in `fgclustering/distance.py` updated to describe the new
   effective-ancestor semantics.
+- `DistanceRandomForestProximity.__init__` now accepts `max_depth_for_proximity` and
+  validates it (must be a non-negative integer when not `None`). The
+  `_validate_mutually_exclusive` call is extended to cover both
+  `min_samples_in_node` and `max_depth_for_proximity`; setting both at once raises
+  `ValueError`.
+- `DistanceRandomForestProximity.calculate_terminals` dispatches to a second
+  ancestor-collapse branch when `max_depth_for_proximity` is configured. Behavior
+  with both new parameters set to `None` (default) is byte-for-byte identical to
+  previous releases.
+- `DistanceRandomForestProximity` class docstring updated to enumerate both supported
+  ancestor-collapse criteria and document their mutual exclusivity.
 
 ### Known limitations
 - `DistanceRandomForestLCA` paired with `ClusteringClara` is not fully LCA-consistent

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -31,9 +31,17 @@ class DistanceRandomForestProximity:
 
     Sample similarity is derived from how often two samples fall into the same terminal node
     across trees. Distances are defined as one minus this proximity. Optionally, leaves can be
-    collapsed to a coarser ancestor according to a structural criterion (``min_samples_in_node``),
-    which reduces proximity sparsity for deep regression forests. The distance matrix can be
-    computed fully in memory or stored in a disk-backed memmap array for memory-efficient operation.
+    collapsed to a coarser ancestor according to one of the supported structural criteria,
+    which reduces proximity sparsity for deep regression forests:
+
+    * ``min_samples_in_node`` - collapse to the nearest ancestor whose ``n_node_samples`` is at
+      least the given threshold.
+    * ``max_depth_for_proximity`` - collapse to the nearest ancestor whose depth in the tree is
+      at most the given threshold (``0`` collapses every leaf to the root).
+
+    The two ancestor-collapse parameters are mutually exclusive. The distance matrix can be
+    computed fully in memory or stored in a disk-backed memmap array for memory-efficient
+    operation.
 
     :param memory_efficient: Whether to store the distance matrix in a disk-backed memmap array.
     :type memory_efficient: bool
@@ -42,8 +50,16 @@ class DistanceRandomForestProximity:
     :param min_samples_in_node: Minimum ``n_node_samples`` required for a node to be used as
         an effective leaf. Each leaf is replaced by the nearest ancestor that has at least this
         many training samples (falling back to the root if no ancestor satisfies the criterion).
-        Defaults to ``None``.
+        Defaults to ``None``, which preserves standard terminal-node proximity. Mutually
+        exclusive with ``max_depth_for_proximity``.
     :type min_samples_in_node: int | None
+    :param max_depth_for_proximity: Maximum tree depth at which a node is eligible to act as
+        an effective leaf. Each leaf is replaced by the nearest ancestor whose depth is less
+        than or equal to this threshold; if the leaf itself is already at depth at most the
+        threshold, it is kept. ``0`` collapses every sample to the root. Defaults to ``None``,
+        which preserves standard terminal-node proximity. Mutually exclusive with
+        ``min_samples_in_node``.
+    :type max_depth_for_proximity: int | None
     """
 
     def __init__(
@@ -51,25 +67,29 @@ class DistanceRandomForestProximity:
         memory_efficient: bool = False,
         dir_distance_matrix: str | None = None,
         min_samples_in_node: int | None = None,
+        max_depth_for_proximity: int | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestProximity class."""
         if memory_efficient:
             if dir_distance_matrix is None:
                 raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
 
-        if min_samples_in_node is not None and (
-            isinstance(min_samples_in_node, bool)
-            or not isinstance(min_samples_in_node, int)
-            or min_samples_in_node < 1
-        ):
+        if min_samples_in_node is not None and min_samples_in_node < 1:
             raise ValueError("`min_samples_in_node` must be a positive integer.")
 
-        _validate_mutually_exclusive(min_samples_in_node=min_samples_in_node)
+        if max_depth_for_proximity is not None and max_depth_for_proximity < 0:
+            raise ValueError("`max_depth_for_proximity` must be a non-negative integer.")
+
+        _validate_mutually_exclusive(
+            min_samples_in_node=min_samples_in_node,
+            max_depth_for_proximity=max_depth_for_proximity,
+        )
 
         self.terminals: np.ndarray | None = None
         self.memory_efficient = memory_efficient
         self.dir_distance_matrix = dir_distance_matrix
         self.min_samples_in_node = min_samples_in_node
+        self.max_depth_for_proximity = max_depth_for_proximity
         self.precomputed_distance_matrix = None
 
     def calculate_terminals(
@@ -81,9 +101,11 @@ class DistanceRandomForestProximity:
         Compute and store the terminal-node (or effective-ancestor) assignments of all samples across all trees.
 
         Terminal node IDs are obtained by applying the trained Random Forest to ``X``. When an
-        ancestor-collapse criterion is configured on the class (e.g. ``min_samples_in_node``), each
-        terminal id is replaced by the id of the nearest ancestor that satisfies the criterion.
-        Each row of the stored matrix corresponds to a sample and each column to a tree.
+        ancestor-collapse criterion is configured on the class (``min_samples_in_node`` or
+        ``max_depth_for_proximity``), each terminal id is replaced by the id of the nearest
+        ancestor that satisfies the criterion. The two criteria are mutually exclusive (validated
+        at construction time). Each row of the stored matrix corresponds to a sample and each
+        column to a tree.
 
         :param estimator: Trained Random Forest estimator.
         :type estimator: RandomForestClassifier | RandomForestRegressor
@@ -100,6 +122,14 @@ class DistanceRandomForestProximity:
             self.terminals = self._collapse_terminals(
                 estimator=estimator,
                 predicate_factory=lambda tree: (lambda node: tree.n_node_samples[node] >= min_samples),
+            )
+        elif self.max_depth_for_proximity is not None:
+            max_depth = self.max_depth_for_proximity
+            self.terminals = self._collapse_terminals(
+                estimator=estimator,
+                predicate_factory=lambda tree: (
+                    lambda node, _depths=_compute_node_depths(tree): _depths[node] <= max_depth
+                ),
             )
 
     def _collapse_terminals(

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -169,6 +169,73 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
 
+    def test_max_depth_for_proximity_none_matches_baseline(self):
+        """Default behavior (max_depth_for_proximity=None) must match pre-feature output."""
+        dist_baseline = DistanceRandomForestProximity()
+        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
+
+        dist_new = DistanceRandomForestProximity(max_depth_for_proximity=None)
+        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
+
+        np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_max_depth_for_proximity_zero_collapses_to_root(self):
+        """A threshold of 0 forces every leaf to the root -> distance matrix is all zeros."""
+        dist = DistanceRandomForestProximity(max_depth_for_proximity=0)
+        dist.calculate_terminals(estimator=self.model, X=self.X)
+        matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
+        self.assertTrue(np.all(matrix == 0.0))
+
+    def test_max_depth_for_proximity_large_matches_baseline(self):
+        """A very large threshold leaves every leaf untouched -> identical to baseline."""
+        dist_baseline = DistanceRandomForestProximity()
+        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
+
+        dist_new = DistanceRandomForestProximity(max_depth_for_proximity=10_000)
+        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
+
+        np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_max_depth_for_proximity_monotonicity(self):
+        """Mean off-diagonal distance is non-decreasing as the depth threshold grows."""
+        means = []
+        for threshold in [0, 1, 2, 3, 5, 10, 100]:
+            dist = DistanceRandomForestProximity(max_depth_for_proximity=threshold)
+            dist.calculate_terminals(estimator=self.model, X=self.X)
+            matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
+            n = matrix.shape[0]
+            off_diag = matrix[~np.eye(n, dtype=bool)]
+            means.append(float(off_diag.mean()))
+        for a, b in zip(means, means[1:]):
+            self.assertGreaterEqual(b, a - 1e-8)
+
+    def test_max_depth_for_proximity_invalid_raises(self):
+        """Negative thresholds are rejected at construction; 0 is allowed."""
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(max_depth_for_proximity=-1)
+        DistanceRandomForestProximity(max_depth_for_proximity=0)
+
+    def test_max_depth_for_proximity_preserves_shape_and_symmetry(self):
+        """Collapsed matrix keeps the symmetric / zero-diagonal contract."""
+        dist = DistanceRandomForestProximity(max_depth_for_proximity=3)
+        dist.calculate_terminals(estimator=self.model, X=self.X)
+        matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
+        self.assertEqual(matrix.shape, (len(self.X), len(self.X)))
+        self.assertTrue(np.allclose(matrix, matrix.T))
+        self.assertTrue(np.all(np.diag(matrix) == 0))
+
+    def test_min_samples_and_max_depth_mutually_exclusive(self):
+        """Setting both ancestor-collapse parameters at once must raise ValueError."""
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(
+                min_samples_in_node=5,
+                max_depth_for_proximity=3,
+            )
+
 
 class TestDistanceRandomForestLCA(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

This pull request adds a second **structural** ancestor-collapse criterion on `DistanceRandomForestProximity`: **`max_depth_for_proximity`**. Each sample’s leaf is remapped to the **nearest ancestor whose depth is at most the given threshold**, which caps how fine-grained the proximity partition is and reduces sparsity for very deep regression forests. **`0`** maps every leaf to the **root**; large values recover standard **terminal-node** proximity.

## Motivation

Issue **#27** explores inner-node / structural proximity strategies. The base branch already supports sample-count–based collapse (`min_samples_in_node`). Depth-based collapse gives an orthogonal knob: control granularity by **tree depth** rather than by **`n_node_samples`**.

## What changed

- **`DistanceRandomForestProximity`**
  - New optional constructor argument **`max_depth_for_proximity: int | None`** (default `None` = unchanged behavior).
  - Validation: must be a **non-negative** integer when set.
  - **`calculate_terminals`**: when `max_depth_for_proximity` is set, terminals are collapsed via the existing **`_collapse_terminals`** pipeline with a depth predicate built from **`_compute_node_depths`** (already on the base branch for LCA-related work).
- **Mutual exclusivity**: **`min_samples_in_node`** and **`max_depth_for_proximity`** cannot both be set; **`_validate_mutually_exclusive`** is extended accordingly.
- **Documentation**: class and method docstrings plus **`CHANGELOG.md`** under [Unreleased].

## Tests

- **`test/test_distance.py`**: baseline parity (`None`, very large depth), root collapse for `0`, monotonicity, invalid input, shape/symmetry, and mutual exclusivity with `min_samples_in_node`.

Closes #40 