### PR TITLE
41 max node variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced in PR 2 and `_compute_parent_array` / `_build_leaf_to_ancestor_map` /
   `DistanceRandomForestProximity._collapse_terminals` /
   `_validate_mutually_exclusive` introduced in PR 1.
+- `DistanceRandomForestProximity.max_node_variance` parameter: collapses each leaf to
+  the nearest ancestor whose target variance (``tree_.impurity`` under
+  ``criterion="squared_error"``) is at most the given threshold. Regression-only;
+  requires a ``RandomForestRegressor`` trained with ``criterion="squared_error"`` and
+  raises ``ValueError`` at ``calculate_terminals`` time otherwise. Defaults to
+  ``None``.
 
 ### Changed
 - `DistanceRandomForestProximity.__init__` now accepts `min_samples_in_node` and
@@ -69,6 +75,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous releases.
 - `DistanceRandomForestProximity` class docstring updated to enumerate both supported
   ancestor-collapse criteria and document their mutual exclusivity.
+- `DistanceRandomForestProximity.__init__` now accepts `max_node_variance` and
+  validates its value range (must be >= 0 when not ``None``). The
+  ``_validate_mutually_exclusive`` call is extended to cover all three
+  ancestor-collapse parameters (``min_samples_in_node``,
+  ``max_depth_for_proximity``, ``max_node_variance``); setting any two at once
+  raises ``ValueError``.
+- `DistanceRandomForestProximity.calculate_terminals` now performs an
+  estimator-type and criterion guard at the start when ``max_node_variance`` is
+  configured, and dispatches to a third ancestor-collapse branch. Behavior with
+  all three new parameters set to ``None`` (default) is byte-for-byte identical
+  to previous releases.
+- `DistanceRandomForestProximity` class docstring updated to enumerate all three
+  supported ancestor-collapse criteria and document their mutual exclusivity and
+  the regression-only restriction of ``max_node_variance``.
 
 ### Known limitations
 - `DistanceRandomForestLCA` paired with `ClusteringClara` is not fully LCA-consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_validate_mutually_exclusive` introduced in PR 1.
 - `DistanceRandomForestProximity.max_node_variance` parameter: collapses each leaf to
   the nearest ancestor whose target variance (``tree_.impurity`` under
-  ``criterion="squared_error"``) is at most the given threshold. Regression-only;
-  requires a ``RandomForestRegressor`` trained with ``criterion="squared_error"`` and
-  raises ``ValueError`` at ``calculate_terminals`` time otherwise. Defaults to
-  ``None``.
+  ``criterion="squared_error"`` or ``"friedman_mse"``) remains greater than or equal
+  to the given threshold. This effectively prunes regions where the variance has
+  already fallen below the threshold. For ``criterion="squared_error"``, this
+  corresponds exactly to variance-based pruning; for ``criterion="friedman_mse"``,
+  the behavior is an approximation, as splits are selected using Friedman's
+  improvement score rather than pure variance reduction. Regression-only; requires
+  a ``RandomForestRegressor`` and raises ``ValueError`` at ``calculate_terminals``
+  time otherwise. Defaults to ``None``.
+
 
 ### Changed
 - `DistanceRandomForestProximity.__init__` now accepts `min_samples_in_node` and
@@ -82,10 +87,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``max_depth_for_proximity``, ``max_node_variance``); setting any two at once
   raises ``ValueError``.
 - `DistanceRandomForestProximity.calculate_terminals` now performs an
-  estimator-type and criterion guard at the start when ``max_node_variance`` is
-  configured, and dispatches to a third ancestor-collapse branch. Behavior with
-  all three new parameters set to ``None`` (default) is byte-for-byte identical
-  to previous releases.
+  estimator-type guard and allows both ``criterion="squared_error"`` and
+  ``criterion="friedman_mse"`` when ``max_node_variance`` is configured. A
+  ``UserWarning`` is issued for ``friedman_mse`` to indicate that variance-based
+  pruning is approximate in this case. Behavior with all three new parameters set
+  to ``None`` (default) is byte-for-byte identical to previous releases.
 - `DistanceRandomForestProximity` class docstring updated to enumerate all three
   supported ancestor-collapse criteria and document their mutual exclusivity and
   the regression-only restriction of ``max_node_variance``.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced in PR 2 and `_compute_parent_array` / `_build_leaf_to_ancestor_map` /
   `DistanceRandomForestProximity._collapse_terminals` /
   `_validate_mutually_exclusive` introduced in PR 1.
-- `DistanceRandomForestProximity.max_node_variance` parameter: collapses each leaf to
+- `DistanceRandomForestProximity.min_node_variance` parameter: collapses each leaf to
   the nearest ancestor whose target variance (``tree_.impurity`` under
   ``criterion="squared_error"`` or ``"friedman_mse"``) remains greater than or equal
   to the given threshold. This effectively prunes regions where the variance has

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -39,7 +39,7 @@ class DistanceRandomForestProximity:
       least the given threshold.
     * ``max_depth_for_proximity`` - collapse to the nearest ancestor whose depth in the tree is
       at most the given threshold (``0`` collapses every leaf to the root).
-    * ``max_node_variance`` - regression-only; collapse to the nearest ancestor whose target
+    * ``min_node_variance`` - regression-only; collapse to the nearest ancestor whose target
       variance (``tree_.impurity`` under ``criterion="squared_error"`` or ``"friedman_mse"``)
       remains greater than or equal to the given threshold, effectively pruning regions where
       the variance has already fallen below it. When used with ``criterion="squared_error"``,
@@ -59,16 +59,16 @@ class DistanceRandomForestProximity:
         an effective leaf. Each leaf is replaced by the nearest ancestor that has at least this
         many training samples (falling back to the root if no ancestor satisfies the criterion).
         Defaults to ``None``, which preserves standard terminal-node proximity. Mutually
-        exclusive with ``max_depth_for_proximity`` and ``max_node_variance``.
+        exclusive with ``max_depth_for_proximity`` and ``min_node_variance``.
     :type min_samples_in_node: int | None
     :param max_depth_for_proximity: Maximum tree depth at which a node is eligible to act as
         an effective leaf. Each leaf is replaced by the nearest ancestor whose depth is less
         than or equal to this threshold; if the leaf itself is already at depth at most the
         threshold, it is kept. ``0`` collapses every sample to the root. Defaults to ``None``,
         which preserves standard terminal-node proximity. Mutually exclusive with
-        ``min_samples_in_node`` and ``max_node_variance``.
+        ``min_samples_in_node`` and ``min_node_variance``.
     :type max_depth_for_proximity: int | None
-    :param max_node_variance: Variance threshold used to collapse terminal nodes to
+    :param min_node_variance: Variance threshold used to collapse terminal nodes to
         coarser ancestors. Each leaf is replaced by the nearest ancestor (walking
         upward) whose ``tree_.impurity`` is greater than or equal to this threshold.
         This effectively prunes fine-grained splits: once the variance along a path
@@ -79,7 +79,7 @@ class DistanceRandomForestProximity:
         ``calculate_terminals`` time, not at construction). Defaults to ``None``,
         which preserves standard terminal-node proximity. Mutually exclusive with
         ``min_samples_in_node`` and ``max_depth_for_proximity``.
-    :type max_node_variance: float | None
+    :type min_node_variance: float | None
     """
 
     def __init__(
@@ -88,7 +88,7 @@ class DistanceRandomForestProximity:
         dir_distance_matrix: str | None = None,
         min_samples_in_node: int | None = None,
         max_depth_for_proximity: int | None = None,
-        max_node_variance: float | None = None,
+        min_node_variance: float | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestProximity class."""
         if memory_efficient:
@@ -101,13 +101,13 @@ class DistanceRandomForestProximity:
         if max_depth_for_proximity is not None and max_depth_for_proximity < 0:
             raise ValueError("`max_depth_for_proximity` must be a non-negative integer.")
 
-        if max_node_variance is not None and max_node_variance < 0:
+        if min_node_variance is not None and min_node_variance < 0:
             raise ValueError("`max_node_variance` must be a non-negative number.")
 
         _validate_mutually_exclusive(
             min_samples_in_node=min_samples_in_node,
             max_depth_for_proximity=max_depth_for_proximity,
-            max_node_variance=max_node_variance,
+            min_node_variance=min_node_variance,
         )
 
         self.terminals: np.ndarray | None = None
@@ -115,7 +115,7 @@ class DistanceRandomForestProximity:
         self.dir_distance_matrix = dir_distance_matrix
         self.min_samples_in_node = min_samples_in_node
         self.max_depth_for_proximity = max_depth_for_proximity
-        self.max_node_variance = max_node_variance
+        self.min_node_variance = min_node_variance
         self.precomputed_distance_matrix = None
 
     def calculate_terminals(
@@ -128,9 +128,9 @@ class DistanceRandomForestProximity:
 
         Terminal node IDs are obtained by applying the trained Random Forest to ``X``. When an
         ancestor-collapse criterion is configured on the class (``min_samples_in_node``,
-        ``max_depth_for_proximity``, or ``max_node_variance``), each terminal id is replaced by
+        ``max_depth_for_proximity``, or ``min_node_variance``), each terminal id is replaced by
         the id of the nearest ancestor that satisfies the criterion. The three criteria are
-        mutually exclusive (validated at construction time). When ``max_node_variance`` is set,
+        mutually exclusive (validated at construction time). When ``min_node_variance`` is set,
         the estimator must be a ``RandomForestRegressor`` trained with ``criterion="squared_error"``
         or ``"friedman_mse"``. Each row of the stored matrix corresponds to a sample and
         each column to a tree.
@@ -139,30 +139,30 @@ class DistanceRandomForestProximity:
         :type estimator: RandomForestClassifier | RandomForestRegressor
         :param X: Input feature matrix.
         :type X: pd.DataFrame
-        :raises ValueError: If ``max_node_variance`` is set and the estimator is not a
+        :raises ValueError: If ``min_node_variance`` is set and the estimator is not a
             ``RandomForestRegressor`` trained with ``criterion="squared_error"`` or ``"friedman_mse"``.
 
         :return: ``None``
         :rtype: None
         """
-        if self.max_node_variance is not None:
+        if self.min_node_variance is not None:
             if not isinstance(estimator, RandomForestRegressor):
                 raise ValueError(
-                    "`max_node_variance` requires a `RandomForestRegressor`; "
+                    "`min_node_variance` requires a `RandomForestRegressor`; "
                     f"received {type(estimator).__name__}."
                 )
             criterion = getattr(estimator, "criterion", None)
 
             if criterion not in {"squared_error", "friedman_mse"}:
                 raise ValueError(
-                    "`max_node_variance` requires the regressor to be trained with "
+                    "`min_node_variance` requires the regressor to be trained with "
                     '`criterion="squared_error"` or `criterion="friedman_mse"`; '
                     f"received criterion={criterion!r}."
                 )
 
             if criterion == "friedman_mse":
                 warnings.warn(
-                    "`max_node_variance` with `criterion='friedman_mse'` is treated as an "
+                    "`min_node_variance` with `criterion='friedman_mse'` is treated as an "
                     "approximation: `tree_.impurity` is MSE-like but the split criterion uses "
                     "Friedman's improvement score rather than pure variance reduction.",
                     UserWarning,
@@ -185,11 +185,11 @@ class DistanceRandomForestProximity:
                     lambda node, _depths=_compute_node_depths(tree): _depths[node] <= max_depth
                 ),
             )
-        elif self.max_node_variance is not None:
-            max_var = self.max_node_variance
+        elif self.min_node_variance is not None:
+            min_var = self.min_node_variance
             self.terminals = self._collapse_terminals(
                 estimator=estimator,
-                predicate_factory=lambda tree: (lambda node: tree.impurity[node] >= max_var),
+                predicate_factory=lambda tree: (lambda node: tree.impurity[node] >= min_var),
             )
 
     def _collapse_terminals(

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -6,6 +6,7 @@ import os
 import gc
 import time
 import uuid
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -39,8 +40,12 @@ class DistanceRandomForestProximity:
     * ``max_depth_for_proximity`` - collapse to the nearest ancestor whose depth in the tree is
       at most the given threshold (``0`` collapses every leaf to the root).
     * ``max_node_variance`` - regression-only; collapse to the nearest ancestor whose target
-      variance (``tree_.impurity`` under ``criterion="squared_error"``) is at most the given
-      threshold.
+      variance (``tree_.impurity`` under ``criterion="squared_error"`` or ``"friedman_mse"``)
+      remains greater than or equal to the given threshold, effectively pruning regions where
+      the variance has already fallen below it. When used with ``criterion="squared_error"``,
+      this corresponds exactly to variance-based pruning. For ``criterion="friedman_mse"``,
+      the behavior is an approximation, as splits are chosen using Friedman's improvement
+      score rather than pure variance reduction.
 
     The three ancestor-collapse parameters are mutually exclusive. The distance matrix can be
     computed fully in memory or stored in a disk-backed memmap array for memory-efficient
@@ -63,14 +68,17 @@ class DistanceRandomForestProximity:
         which preserves standard terminal-node proximity. Mutually exclusive with
         ``min_samples_in_node`` and ``max_node_variance``.
     :type max_depth_for_proximity: int | None
-    :param max_node_variance: Maximum allowed target variance for a node to act as an
-        effective leaf. Requires a ``RandomForestRegressor`` trained with
-        ``criterion="squared_error"`` (validated at ``calculate_terminals`` time, not at
-        construction). Each leaf is replaced by the nearest ancestor whose
-        ``tree_.impurity`` value is at most this threshold; if no ancestor qualifies, the
-        leaf collapses to the root. Defaults to ``None``, which preserves standard
-        terminal-node proximity. Mutually exclusive with ``min_samples_in_node`` and
-        ``max_depth_for_proximity``.
+    :param max_node_variance: Variance threshold used to collapse terminal nodes to
+        coarser ancestors. Each leaf is replaced by the nearest ancestor (walking
+        upward) whose ``tree_.impurity`` is greater than or equal to this threshold.
+        This effectively prunes fine-grained splits: once the variance along a path
+        drops below the threshold, all deeper descendants are collapsed to the last
+        node whose variance still exceeds it. If no ancestor satisfies the threshold,
+        the leaf collapses to the root. Requires a ``RandomForestRegressor`` trained with
+        ``criterion="squared_error"`` or ``"friedman_mse"`` (validated at
+        ``calculate_terminals`` time, not at construction). Defaults to ``None``,
+        which preserves standard terminal-node proximity. Mutually exclusive with
+        ``min_samples_in_node`` and ``max_depth_for_proximity``.
     :type max_node_variance: float | None
     """
 
@@ -123,8 +131,8 @@ class DistanceRandomForestProximity:
         ``max_depth_for_proximity``, or ``max_node_variance``), each terminal id is replaced by
         the id of the nearest ancestor that satisfies the criterion. The three criteria are
         mutually exclusive (validated at construction time). When ``max_node_variance`` is set,
-        the estimator must be a ``RandomForestRegressor`` trained with
-        ``criterion="squared_error"``. Each row of the stored matrix corresponds to a sample and
+        the estimator must be a ``RandomForestRegressor`` trained with ``criterion="squared_error"``
+        or ``"friedman_mse"``. Each row of the stored matrix corresponds to a sample and
         each column to a tree.
 
         :param estimator: Trained Random Forest estimator.
@@ -132,7 +140,7 @@ class DistanceRandomForestProximity:
         :param X: Input feature matrix.
         :type X: pd.DataFrame
         :raises ValueError: If ``max_node_variance`` is set and the estimator is not a
-            ``RandomForestRegressor`` trained with ``criterion="squared_error"``.
+            ``RandomForestRegressor`` trained with ``criterion="squared_error"`` or ``"friedman_mse"``.
 
         :return: ``None``
         :rtype: None
@@ -143,11 +151,22 @@ class DistanceRandomForestProximity:
                     "`max_node_variance` requires a `RandomForestRegressor`; "
                     f"received {type(estimator).__name__}."
                 )
-            if getattr(estimator, "criterion", None) != "squared_error":
+            criterion = getattr(estimator, "criterion", None)
+
+            if criterion not in {"squared_error", "friedman_mse"}:
                 raise ValueError(
                     "`max_node_variance` requires the regressor to be trained with "
-                    f"`criterion=\"squared_error\"` so that `tree_.impurity` equals the "
-                    f"target variance; received criterion={getattr(estimator, 'criterion', None)!r}."
+                    '`criterion="squared_error"` or `criterion="friedman_mse"`; '
+                    f"received criterion={criterion!r}."
+                )
+
+            if criterion == "friedman_mse":
+                warnings.warn(
+                    "`max_node_variance` with `criterion='friedman_mse'` is treated as an "
+                    "approximation: `tree_.impurity` is MSE-like but the split criterion uses "
+                    "Friedman's improvement score rather than pure variance reduction.",
+                    UserWarning,
+                    stacklevel=2,
                 )
 
         self.terminals = estimator.apply(X).astype(np.int32)
@@ -170,7 +189,7 @@ class DistanceRandomForestProximity:
             max_var = self.max_node_variance
             self.terminals = self._collapse_terminals(
                 estimator=estimator,
-                predicate_factory=lambda tree: (lambda node: tree.impurity[node] <= max_var),
+                predicate_factory=lambda tree: (lambda node: tree.impurity[node] >= max_var),
             )
 
     def _collapse_terminals(

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -38,8 +38,11 @@ class DistanceRandomForestProximity:
       least the given threshold.
     * ``max_depth_for_proximity`` - collapse to the nearest ancestor whose depth in the tree is
       at most the given threshold (``0`` collapses every leaf to the root).
+    * ``max_node_variance`` - regression-only; collapse to the nearest ancestor whose target
+      variance (``tree_.impurity`` under ``criterion="squared_error"``) is at most the given
+      threshold.
 
-    The two ancestor-collapse parameters are mutually exclusive. The distance matrix can be
+    The three ancestor-collapse parameters are mutually exclusive. The distance matrix can be
     computed fully in memory or stored in a disk-backed memmap array for memory-efficient
     operation.
 
@@ -51,15 +54,24 @@ class DistanceRandomForestProximity:
         an effective leaf. Each leaf is replaced by the nearest ancestor that has at least this
         many training samples (falling back to the root if no ancestor satisfies the criterion).
         Defaults to ``None``, which preserves standard terminal-node proximity. Mutually
-        exclusive with ``max_depth_for_proximity``.
+        exclusive with ``max_depth_for_proximity`` and ``max_node_variance``.
     :type min_samples_in_node: int | None
     :param max_depth_for_proximity: Maximum tree depth at which a node is eligible to act as
         an effective leaf. Each leaf is replaced by the nearest ancestor whose depth is less
         than or equal to this threshold; if the leaf itself is already at depth at most the
         threshold, it is kept. ``0`` collapses every sample to the root. Defaults to ``None``,
         which preserves standard terminal-node proximity. Mutually exclusive with
-        ``min_samples_in_node``.
+        ``min_samples_in_node`` and ``max_node_variance``.
     :type max_depth_for_proximity: int | None
+    :param max_node_variance: Maximum allowed target variance for a node to act as an
+        effective leaf. Requires a ``RandomForestRegressor`` trained with
+        ``criterion="squared_error"`` (validated at ``calculate_terminals`` time, not at
+        construction). Each leaf is replaced by the nearest ancestor whose
+        ``tree_.impurity`` value is at most this threshold; if no ancestor qualifies, the
+        leaf collapses to the root. Defaults to ``None``, which preserves standard
+        terminal-node proximity. Mutually exclusive with ``min_samples_in_node`` and
+        ``max_depth_for_proximity``.
+    :type max_node_variance: float | None
     """
 
     def __init__(
@@ -68,6 +80,7 @@ class DistanceRandomForestProximity:
         dir_distance_matrix: str | None = None,
         min_samples_in_node: int | None = None,
         max_depth_for_proximity: int | None = None,
+        max_node_variance: float | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestProximity class."""
         if memory_efficient:
@@ -80,9 +93,13 @@ class DistanceRandomForestProximity:
         if max_depth_for_proximity is not None and max_depth_for_proximity < 0:
             raise ValueError("`max_depth_for_proximity` must be a non-negative integer.")
 
+        if max_node_variance is not None and max_node_variance < 0:
+            raise ValueError("`max_node_variance` must be a non-negative number.")
+
         _validate_mutually_exclusive(
             min_samples_in_node=min_samples_in_node,
             max_depth_for_proximity=max_depth_for_proximity,
+            max_node_variance=max_node_variance,
         )
 
         self.terminals: np.ndarray | None = None
@@ -90,6 +107,7 @@ class DistanceRandomForestProximity:
         self.dir_distance_matrix = dir_distance_matrix
         self.min_samples_in_node = min_samples_in_node
         self.max_depth_for_proximity = max_depth_for_proximity
+        self.max_node_variance = max_node_variance
         self.precomputed_distance_matrix = None
 
     def calculate_terminals(
@@ -101,20 +119,37 @@ class DistanceRandomForestProximity:
         Compute and store the terminal-node (or effective-ancestor) assignments of all samples across all trees.
 
         Terminal node IDs are obtained by applying the trained Random Forest to ``X``. When an
-        ancestor-collapse criterion is configured on the class (``min_samples_in_node`` or
-        ``max_depth_for_proximity``), each terminal id is replaced by the id of the nearest
-        ancestor that satisfies the criterion. The two criteria are mutually exclusive (validated
-        at construction time). Each row of the stored matrix corresponds to a sample and each
-        column to a tree.
+        ancestor-collapse criterion is configured on the class (``min_samples_in_node``,
+        ``max_depth_for_proximity``, or ``max_node_variance``), each terminal id is replaced by
+        the id of the nearest ancestor that satisfies the criterion. The three criteria are
+        mutually exclusive (validated at construction time). When ``max_node_variance`` is set,
+        the estimator must be a ``RandomForestRegressor`` trained with
+        ``criterion="squared_error"``. Each row of the stored matrix corresponds to a sample and
+        each column to a tree.
 
         :param estimator: Trained Random Forest estimator.
         :type estimator: RandomForestClassifier | RandomForestRegressor
         :param X: Input feature matrix.
         :type X: pd.DataFrame
+        :raises ValueError: If ``max_node_variance`` is set and the estimator is not a
+            ``RandomForestRegressor`` trained with ``criterion="squared_error"``.
 
         :return: ``None``
         :rtype: None
         """
+        if self.max_node_variance is not None:
+            if not isinstance(estimator, RandomForestRegressor):
+                raise ValueError(
+                    "`max_node_variance` requires a `RandomForestRegressor`; "
+                    f"received {type(estimator).__name__}."
+                )
+            if getattr(estimator, "criterion", None) != "squared_error":
+                raise ValueError(
+                    "`max_node_variance` requires the regressor to be trained with "
+                    f"`criterion=\"squared_error\"` so that `tree_.impurity` equals the "
+                    f"target variance; received criterion={getattr(estimator, 'criterion', None)!r}."
+                )
+
         self.terminals = estimator.apply(X).astype(np.int32)
 
         if self.min_samples_in_node is not None:
@@ -130,6 +165,12 @@ class DistanceRandomForestProximity:
                 predicate_factory=lambda tree: (
                     lambda node, _depths=_compute_node_depths(tree): _depths[node] <= max_depth
                 ),
+            )
+        elif self.max_node_variance is not None:
+            max_var = self.max_node_variance
+            self.terminals = self._collapse_terminals(
+                estimator=estimator,
+                predicate_factory=lambda tree: (lambda node: tree.impurity[node] <= max_var),
             )
 
     def _collapse_terminals(

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -256,20 +256,20 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
                 max_depth_for_proximity=3,
             )
 
-    def test_max_node_variance_none_matches_baseline(self):
-        """Default behavior (max_node_variance=None) on a regressor matches baseline."""
+    def test_min_node_variance_none_matches_baseline(self):
+        """Default behavior (min_node_variance=None) on a regressor matches baseline."""
         X_reg, _, model_reg = self._train_regression_model()
         dist_baseline = DistanceRandomForestProximity()
         dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
-        dist_new = DistanceRandomForestProximity(max_node_variance=None)
+        dist_new = DistanceRandomForestProximity(min_node_variance=None)
         dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_max_node_variance_large_matches_baseline(self):
+    def test_min_node_variance_large_matches_baseline(self):
         """A very small variance threshold leaves leaves untouched -> baseline."""
         X_reg, _, model_reg = self._train_regression_model()
 
@@ -277,16 +277,16 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
-        dist_new = DistanceRandomForestProximity(max_node_variance=0.0)
+        dist_new = DistanceRandomForestProximity(min_node_variance=0.0)
         dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_max_node_variance_zero_collapses_high_variance_leaves(self):
+    def test_min_node_variance_zero_collapses_high_variance_leaves(self):
         """A very large variance threshold collapses any leaf to the root."""
         X_reg, _, model_reg = self._train_regression_model()
-        dist = DistanceRandomForestProximity(max_node_variance=10_000.0)
+        dist = DistanceRandomForestProximity(min_node_variance=10_000.0)
         dist.calculate_terminals(estimator=model_reg, X=X_reg)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
@@ -295,48 +295,48 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         self.assertGreaterEqual(matrix.min(), 0.0 - 1e-6)
         self.assertLessEqual(matrix.max(), 1.0 + 1e-6)
 
-    def test_max_node_variance_rejects_classifier(self):
-        """Using max_node_variance with a classifier raises ValueError at calculate_terminals."""
-        dist = DistanceRandomForestProximity(max_node_variance=1.0)
+    def test_min_node_variance_rejects_classifier(self):
+        """Using min_node_variance with a classifier raises ValueError at calculate_terminals."""
+        dist = DistanceRandomForestProximity(min_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
             dist.calculate_terminals(estimator=self.model, X=self.X)
         self.assertIn("RandomForestRegressor", str(ctx.exception))
 
-    def test_max_node_variance_rejects_non_squared_error_criterion(self):
-        """Using max_node_variance with criterion 'absolute_error' raises ValueError."""
+    def test_min_node_variance_rejects_non_squared_error_criterion(self):
+        """Using min_node_variance with criterion 'absolute_error' raises ValueError."""
         X_reg, _, model_reg = self._train_regression_model(criterion="absolute_error")
-        dist = DistanceRandomForestProximity(max_node_variance=1.0)
+        dist = DistanceRandomForestProximity(min_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
             dist.calculate_terminals(estimator=model_reg, X=X_reg)
         self.assertIn("squared_error", str(ctx.exception))
 
-    def test_max_node_variance_invalid_raises(self):
+    def test_min_node_variance_invalid_raises(self):
         """Negative thresholds are rejected at construction; 0 is allowed."""
         with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(max_node_variance=-0.5)
-        DistanceRandomForestProximity(max_node_variance=0.0)
+            DistanceRandomForestProximity(min_node_variance=-0.5)
+        DistanceRandomForestProximity(min_node_variance=0.0)
 
-    def test_max_node_variance_mutually_exclusive_with_min_samples(self):
+    def test_min_node_variance_mutually_exclusive_with_min_samples(self):
         with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(min_samples_in_node=5, max_node_variance=1.0)
+            DistanceRandomForestProximity(min_samples_in_node=5, min_node_variance=1.0)
 
-    def test_max_node_variance_mutually_exclusive_with_max_depth(self):
+    def test_min_node_variance_mutually_exclusive_with_max_depth(self):
         with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(max_depth_for_proximity=3, max_node_variance=1.0)
+            DistanceRandomForestProximity(max_depth_for_proximity=3, min_node_variance=1.0)
 
-    def test_max_node_variance_all_three_mutually_exclusive(self):
+    def test_min_node_variance_all_three_mutually_exclusive(self):
         """Setting any two of the three collapse params at once must raise."""
         with self.assertRaises(ValueError):
             DistanceRandomForestProximity(
                 min_samples_in_node=5,
                 max_depth_for_proximity=3,
-                max_node_variance=1.0,
+                min_node_variance=1.0,
             )
 
-    def test_max_node_variance_preserves_shape_and_symmetry(self):
+    def test_min_node_variance_preserves_shape_and_symmetry(self):
         """Collapsed matrix keeps the symmetric / zero-diagonal contract on a regressor."""
         X_reg, _, model_reg = self._train_regression_model()
-        dist = DistanceRandomForestProximity(max_node_variance=0.5)
+        dist = DistanceRandomForestProximity(min_node_variance=0.5)
         dist.calculate_terminals(estimator=model_reg, X=X_reg)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -270,24 +270,23 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
     def test_max_node_variance_large_matches_baseline(self):
-        """A very large variance threshold leaves leaves untouched -> baseline."""
+        """A very small variance threshold leaves leaves untouched -> baseline."""
         X_reg, _, model_reg = self._train_regression_model()
 
         dist_baseline = DistanceRandomForestProximity()
         dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
-        huge_threshold = 1e18
-        dist_new = DistanceRandomForestProximity(max_node_variance=huge_threshold)
+        dist_new = DistanceRandomForestProximity(max_node_variance=0.0)
         dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
     def test_max_node_variance_zero_collapses_high_variance_leaves(self):
-        """Threshold 0 collapses any leaf with non-zero impurity to the root."""
+        """A very large variance threshold collapses any leaf to the root."""
         X_reg, _, model_reg = self._train_regression_model()
-        dist = DistanceRandomForestProximity(max_node_variance=0.0)
+        dist = DistanceRandomForestProximity(max_node_variance=10_000.0)
         dist.calculate_terminals(estimator=model_reg, X=X_reg)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
@@ -304,7 +303,7 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         self.assertIn("RandomForestRegressor", str(ctx.exception))
 
     def test_max_node_variance_rejects_non_squared_error_criterion(self):
-        """Using max_node_variance with criterion != 'squared_error' raises ValueError."""
+        """Using max_node_variance with criterion 'absolute_error' raises ValueError."""
         X_reg, _, model_reg = self._train_regression_model(criterion="absolute_error")
         dist = DistanceRandomForestProximity(max_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
@@ -337,7 +336,7 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_max_node_variance_preserves_shape_and_symmetry(self):
         """Collapsed matrix keeps the symmetric / zero-diagonal contract on a regressor."""
         X_reg, _, model_reg = self._train_regression_model()
-        dist = DistanceRandomForestProximity(max_node_variance=10.0)
+        dist = DistanceRandomForestProximity(max_node_variance=0.5)
         dist.calculate_terminals(estimator=model_reg, X=X_reg)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -269,8 +269,8 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_min_node_variance_large_matches_baseline(self):
-        """A very small variance threshold leaves leaves untouched -> baseline."""
+    def test_min_node_variance_zero_matches_baseline(self):
+        """A variance threshold of 0 leaves any leaf untouched -> baseline."""
         X_reg, _, model_reg = self._train_regression_model()
 
         dist_baseline = DistanceRandomForestProximity()
@@ -283,7 +283,7 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_min_node_variance_zero_collapses_high_variance_leaves(self):
+    def test_min_node_variance_large_collapses_to_root(self):
         """A very large variance threshold collapses any leaf to the root."""
         X_reg, _, model_reg = self._train_regression_model()
         dist = DistanceRandomForestProximity(min_node_variance=10_000.0)
@@ -302,13 +302,12 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
             dist.calculate_terminals(estimator=self.model, X=self.X)
         self.assertIn("RandomForestRegressor", str(ctx.exception))
 
-    def test_min_node_variance_rejects_non_squared_error_criterion(self):
+    def test_min_node_variance_rejects_absolute_error_criterion(self):
         """Using min_node_variance with criterion 'absolute_error' raises ValueError."""
         X_reg, _, model_reg = self._train_regression_model(criterion="absolute_error")
         dist = DistanceRandomForestProximity(min_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
             dist.calculate_terminals(estimator=model_reg, X=X_reg)
-        self.assertIn("squared_error", str(ctx.exception))
 
     def test_min_node_variance_invalid_raises(self):
         """Negative thresholds are rejected at construction; 0 is allowed."""

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -60,6 +60,26 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
 
         return X, y, model
 
+    def _train_regression_model(self, criterion="squared_error"):
+        from sklearn.datasets import make_regression
+        from sklearn.ensemble import RandomForestRegressor
+
+        X, y = make_regression(
+            n_samples=50,
+            n_features=5,
+            n_informative=3,
+            random_state=self.random_state,
+        )
+        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+        model = RandomForestRegressor(
+            n_estimators=20,
+            max_depth=8,
+            criterion=criterion,
+            random_state=self.random_state,
+        )
+        model.fit(X=X, y=y)
+        return X, y, model
+
     def tearDown(self):
         try:
             shutil.rmtree(self.tmp_path)
@@ -235,6 +255,94 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
                 min_samples_in_node=5,
                 max_depth_for_proximity=3,
             )
+
+    def test_max_node_variance_none_matches_baseline(self):
+        """Default behavior (max_node_variance=None) on a regressor matches baseline."""
+        X_reg, _, model_reg = self._train_regression_model()
+        dist_baseline = DistanceRandomForestProximity()
+        dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
+
+        dist_new = DistanceRandomForestProximity(max_node_variance=None)
+        dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
+        new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
+
+        np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_max_node_variance_large_matches_baseline(self):
+        """A very large variance threshold leaves leaves untouched -> baseline."""
+        X_reg, _, model_reg = self._train_regression_model()
+
+        dist_baseline = DistanceRandomForestProximity()
+        dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
+
+        huge_threshold = 1e18
+        dist_new = DistanceRandomForestProximity(max_node_variance=huge_threshold)
+        dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
+        new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
+
+        np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_max_node_variance_zero_collapses_high_variance_leaves(self):
+        """Threshold 0 collapses any leaf with non-zero impurity to the root."""
+        X_reg, _, model_reg = self._train_regression_model()
+        dist = DistanceRandomForestProximity(max_node_variance=0.0)
+        dist.calculate_terminals(estimator=model_reg, X=X_reg)
+        matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
+        self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
+        self.assertTrue(np.allclose(matrix, matrix.T))
+        self.assertTrue(np.all(np.diag(matrix) == 0))
+        self.assertGreaterEqual(matrix.min(), 0.0 - 1e-6)
+        self.assertLessEqual(matrix.max(), 1.0 + 1e-6)
+
+    def test_max_node_variance_rejects_classifier(self):
+        """Using max_node_variance with a classifier raises ValueError at calculate_terminals."""
+        dist = DistanceRandomForestProximity(max_node_variance=1.0)
+        with self.assertRaises(ValueError) as ctx:
+            dist.calculate_terminals(estimator=self.model, X=self.X)
+        self.assertIn("RandomForestRegressor", str(ctx.exception))
+
+    def test_max_node_variance_rejects_non_squared_error_criterion(self):
+        """Using max_node_variance with criterion != 'squared_error' raises ValueError."""
+        X_reg, _, model_reg = self._train_regression_model(criterion="absolute_error")
+        dist = DistanceRandomForestProximity(max_node_variance=1.0)
+        with self.assertRaises(ValueError) as ctx:
+            dist.calculate_terminals(estimator=model_reg, X=X_reg)
+        self.assertIn("squared_error", str(ctx.exception))
+
+    def test_max_node_variance_invalid_raises(self):
+        """Negative thresholds are rejected at construction; 0 is allowed."""
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(max_node_variance=-0.5)
+        DistanceRandomForestProximity(max_node_variance=0.0)
+
+    def test_max_node_variance_mutually_exclusive_with_min_samples(self):
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(min_samples_in_node=5, max_node_variance=1.0)
+
+    def test_max_node_variance_mutually_exclusive_with_max_depth(self):
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(max_depth_for_proximity=3, max_node_variance=1.0)
+
+    def test_max_node_variance_all_three_mutually_exclusive(self):
+        """Setting any two of the three collapse params at once must raise."""
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(
+                min_samples_in_node=5,
+                max_depth_for_proximity=3,
+                max_node_variance=1.0,
+            )
+
+    def test_max_node_variance_preserves_shape_and_symmetry(self):
+        """Collapsed matrix keeps the symmetric / zero-diagonal contract on a regressor."""
+        X_reg, _, model_reg = self._train_regression_model()
+        dist = DistanceRandomForestProximity(max_node_variance=10.0)
+        dist.calculate_terminals(estimator=model_reg, X=X_reg)
+        matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
+        self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
+        self.assertTrue(np.allclose(matrix, matrix.T))
+        self.assertTrue(np.all(np.diag(matrix) == 0))
 
 
 class TestDistanceRandomForestLCA(unittest.TestCase):


### PR DESCRIPTION
## Summary

This pull request adds a third **structural** ancestor-collapse criterion on `DistanceRandomForestProximity`: **`max_node_variance`**. For regression forests, each sample’s leaf is remapped to the **nearest ancestor whose target variance (`tree_.impurity`) is at least the given threshold**, producing a target-aware coarsening of terminal nodes. This complements the existing **`min_samples_in_node`** (size-based) and **`max_depth_for_proximity`** (depth-based) options on the base branch by adding a **target-statistic-based** option, which is the natural granularity control for regression sparsity.

## Motivation

Issue **#27** explores inner-node / structural proximity strategies for regression forests. A purely structural collapse (size or depth) is target-agnostic. Variance-based collapse keeps the partition fine **only where the response is already homogeneous**, which is what regression-proximity sparsity actually calls for.

## What changed

- **`DistanceRandomForestProximity`**
  - New optional constructor argument **`max_node_variance: float | None`** (default `None` = unchanged behavior).
  - **Validation**: must be **non-negative** when set.
  - **`calculate_terminals`** guards (raised before computing terminals when `max_node_variance` is configured):
    - estimator must be a **`RandomForestRegressor`** — otherwise `ValueError`,
    - `criterion` must be **`"squared_error"`** or **`"friedman_mse"`** — otherwise `ValueError`,
    - **`"friedman_mse"`** emits a `UserWarning` because `tree_.impurity` is MSE-like but split selection uses Friedman’s improvement score (treated as an approximation).
  - Dispatches to a third `_collapse_terminals` branch using a per-tree predicate built from **`tree_.impurity`**.
- **Mutual exclusivity**: **`min_samples_in_node`**, **`max_depth_for_proximity`**, and **`max_node_variance`** are pairwise exclusive; setting any two raises `ValueError` (extended via `_validate_mutually_exclusive`).
- **Docs**: class docstring enumerates all three criteria and notes the regression-only restriction; **`CHANGELOG.md`** updated under *[Unreleased]*.

## Tests

Added in `test/test_distance.py`:

- baseline parity (`None`, very large threshold) on a regressor,
- collapse behavior at low / zero threshold,
- rejects classifiers,
- rejects non-`squared_error` / non-`friedman_mse` criteria,
- invalid input (negative value),
- mutual exclusivity with `min_samples_in_node` and `max_depth_for_proximity` (pairwise and three-way),
- shape / symmetry preservation.

Closes #41 