### PR TITLE
47 pr b refactor distance classes fix type hints unify tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,12 +119,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing is pruned at θ=0).
 
 ### Added (PR-B)
-- `DistanceRandomForestBase`: shared base class for `DistanceRandomForestProximity`
-  and `DistanceRandomForestLCA`. Holds the memmap configuration, the `terminals`
-  attribute, the `_allocate_distance_matrix` helper, and the
-  `remove_distance_matrix` cleanup logic. Exported from the `fgclustering`
-  package for external type hints. Both existing distance classes now inherit
-  from it.
+- `DistanceRandomForestBase`: shared **abstract** base class (`abc.ABC`) for
+  `DistanceRandomForestProximity` and `DistanceRandomForestLCA`. Holds the
+  memmap configuration, the `terminals` attribute, the
+  `_allocate_distance_matrix` helper, and the `remove_distance_matrix`
+  cleanup logic, and declares `calculate_terminals` and
+  `calculate_distance_matrix` as `@abstractmethod` so that the public
+  `DistanceRandomForestBase` type used in `clustering_distance_metric` /
+  `distance_metric` parameters is type-safe (static type checkers see the
+  full proximity interface) and direct instantiation raises `TypeError`.
+  Exported from the `fgclustering` package. Both existing distance classes
+  now inherit from it.
+- `TestDistanceRandomForestBase`: contract tests covering the new
+  ABC behavior (direct instantiation raises `TypeError`, both methods are
+  marked `__isabstractmethod__`, concrete subclasses still instantiate).
 - Targeted unit tests for `_compute_parent_array`, `_compute_node_depths`,
   `_build_leaf_to_ancestor_map`, and `_validate_mutually_exclusive` in a new
   `TestTreeHelpers` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_build_regression_forest` helper shared across test classes. No semantic
   test changes.
 
+### Fixed (PR-B, test unification)
+- `test/test_forest_guided_clustering.py` import error: `DistanceRandomForestProximity`
+  is now imported from `fgclustering.distance` instead of
+  `fgclustering.forest_guided_clustering`. The latter only re-exports
+  `DistanceRandomForestBase` after the PR-B refactor, so the previous import
+  raised `ImportError` at collection time.
+
+### Changed (PR-B, test unification)
+- `test/test_distance.py` and `test/test_forest_guided_clustering.py`: shared
+  fixtures consolidated. `setUp` now builds the classification forest and
+  three regression forests (`squared_error`, `friedman_mse`,
+  `absolute_error`) once via the module-level
+  `_build_classification_forest` / `_build_regression_forest` helpers, and
+  every test reuses these via `self.model_clas` / `self.X_clas` /
+  `self.model_reg_squared` / `self.model_reg_friedman` /
+  `self.model_reg_absolute` (and `self.model_reg` in
+  `test_forest_guided_clustering.py`). All inline `make_classification` /
+  `make_regression` / `RandomForestRegressor` setup inside individual tests
+  removed.
+- `test/test_distance.py`:
+  - Per-attribute renames `self.X → self.X_clas`, `self.y → self.y_clas`,
+    `self.model → self.model_clas` for clarity now that classification and
+    regression fixtures coexist.
+  - `test_min_samples_in_node_one_matches_baseline` and
+    `test_max_depth_for_proximity_large_matches_baseline` now also assert
+    baseline parity on a regressor, absorbing the old standalone
+    `*_baseline_on_regressor` tests.
+  - Dropped the `*_monotonicity` tests for `min_samples_in_node` and
+    `max_depth_for_proximity`; off-diagonal mean monotonicity is not a
+    contracted invariant of bottom-up ancestor collapse and the tests were
+    flaky on small synthetic forests. Direction-of-effect is still covered
+    by the `*_collapses_to_root` and `*_large_matches_baseline` tests.
+  - Pairwise mutual-exclusivity tests renamed to a uniform
+    `test_<param_a>_mutually_exclusive_with_<param_b>` scheme and grouped
+    together with `test_all_three_mutually_exclusive`.
+- `test/test_forest_guided_clustering.py`:
+  - Removed the duplicated `test_forest_guided_clustering_with_lca_regressor`;
+    its coverage is fully subsumed by
+    `test_forest_guided_clustering_with_lca_distance_regression`, which now
+    uses the shared `self.model_reg` fixture.
+  - Module-level `_build_classification_forest` / `_build_regression_forest`
+    helpers added (regressor configurable via `criterion`, `n_estimators`,
+    `max_depth`).
+- `fgclustering/distance.py`: minor docstring/formatting polish in
+  `DistanceRandomForestBase` (wording "consumers" → "users"; a few short
+  one-liners no longer artificially line-wrapped). No behavior change.
+
 ### Known limitations
 - `DistanceRandomForestLCA` paired with `ClusteringClara` is not fully LCA-consistent
   end-to-end. While CLARA uses `calculate_distance_matrix` during medoid search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reflect the bottom-up pruning semantics (every node has variance ≥ 0, so
   nothing is pruned at θ=0).
 
+### Added (PR-B)
+- `DistanceRandomForestBase`: shared base class for `DistanceRandomForestProximity`
+  and `DistanceRandomForestLCA`. Holds the memmap configuration, the `terminals`
+  attribute, the `_allocate_distance_matrix` helper, and the
+  `remove_distance_matrix` cleanup logic. Exported from the `fgclustering`
+  package for external type hints. Both existing distance classes now inherit
+  from it.
+- Targeted unit tests for `_compute_parent_array`, `_compute_node_depths`,
+  `_build_leaf_to_ancestor_map`, and `_validate_mutually_exclusive` in a new
+  `TestTreeHelpers` class.
+- Per-pair invariant test `test_lca_distance_le_terminal_distance` proving LCA
+  distance ≤ terminal-node distance for any pair.
+- Baseline-on-regressor smoke tests for `min_samples_in_node` and
+  `max_depth_for_proximity`.
+- Integration test `test_forest_guided_clustering_with_lca_regressor` driving
+  `forest_guided_clustering()` through `DistanceRandomForestLCA` end to end.
+
+### Changed (PR-B)
+- Type hints on `distance_metric` parameters in `ClusteringKMedoids.run_clustering`,
+  `ClusteringClara.run_clustering`, `Optimizer.__init__`, and
+  `forest_guided_clustering()` now reference `DistanceRandomForestBase`
+  instead of `DistanceRandomForestProximity` so that `DistanceRandomForestLCA`
+  is correctly advertised as supported.
+- `DistanceRandomForestProximity.remove_distance_matrix` and
+  `DistanceRandomForestLCA.remove_distance_matrix` deleted; both classes now
+  inherit the implementation from `DistanceRandomForestBase`.
+- `DistanceRandomForestProximity.calculate_distance_matrix` and
+  `DistanceRandomForestLCA.calculate_distance_matrix` use the inherited
+  `_allocate_distance_matrix` helper, removing ~30 LOC of duplicated memmap
+  bookkeeping per class.
+- `test/test_distance.py` cleanup: imports moved to module level, keyword-style
+  assertion arguments (`first=`, `second=`, `expr=`, `obj=`, `a=`, `v=`)
+  replaced with positional form to match the rest of the test suite, and
+  `_train_regression_model` consolidated into a module-level
+  `_build_regression_forest` helper shared across test classes. No semantic
+  test changes.
+
 ### Known limitations
 - `DistanceRandomForestLCA` paired with `ClusteringClara` is not fully LCA-consistent
   end-to-end. While CLARA uses `calculate_distance_matrix` during medoid search,

--- a/fgclustering/__init__.py
+++ b/fgclustering/__init__.py
@@ -13,6 +13,7 @@ from .forest_guided_clustering import (
 from .clustering import ClusteringKMedoids, ClusteringClara
 
 from .distance import (
+    DistanceRandomForestBase,
     DistanceRandomForestProximity,
     DistanceRandomForestLCA,
     DistanceJensenShannon,
@@ -32,6 +33,7 @@ __all__ = [
     "plot_forest_guided_decision_paths",
     "ClusteringKMedoids",
     "ClusteringClara",
+    "DistanceRandomForestBase",
     "DistanceRandomForestProximity",
     "DistanceRandomForestLCA",
     "DistanceJensenShannon",

--- a/fgclustering/clustering.py
+++ b/fgclustering/clustering.py
@@ -11,7 +11,7 @@ from numba import njit, prange
 
 from imblearn.under_sampling import RandomUnderSampler
 
-from .distance import DistanceRandomForestProximity
+from .distance import DistanceRandomForestBase
 from .utils import check_sub_sample_size, custom_round
 
 ############################################
@@ -55,7 +55,7 @@ class ClusteringKMedoids:
     def run_clustering(
         self,
         k: int,
-        distance_metric: DistanceRandomForestProximity,
+        distance_metric: DistanceRandomForestBase,
         sample_indices: np.ndarray,
         random_state_subsampling: int | None,
         verbose: int,
@@ -70,7 +70,7 @@ class ClusteringKMedoids:
         :param k: Number of clusters.
         :type k: int
         :param distance_metric: Distance metric object with precomputed Random Forest terminal nodes.
-        :type distance_metric: DistanceRandomForestProximity
+        :type distance_metric: DistanceRandomForestBase
         :param sample_indices: Indices of the samples to cluster.
         :type sample_indices: np.ndarray
         :param random_state_subsampling: Optional subsampling seed. Not used in this implementation.
@@ -156,7 +156,7 @@ class ClusteringClara:
     def run_clustering(
         self,
         k: int,
-        distance_metric: DistanceRandomForestProximity,
+        distance_metric: DistanceRandomForestBase,
         sample_indices: np.ndarray,
         random_state_subsampling: int | None,
         verbose: int,
@@ -172,7 +172,7 @@ class ClusteringClara:
         :param k: Number of clusters.
         :type k: int
         :param distance_metric: Distance metric object with precomputed Random Forest terminal nodes.
-        :type distance_metric: DistanceRandomForestProximity
+        :type distance_metric: DistanceRandomForestBase
         :param sample_indices: Indices of the samples to cluster.
         :type sample_indices: np.ndarray
         :param random_state_subsampling: Optional random seed controlling CLARA subsampling; if ``None``, the instance-level ``random_state`` is used.

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from abc import ABC, abstractmethod
 from numba import njit, prange
 from typing import Callable
 
@@ -25,16 +26,19 @@ from .utils import check_disk_space
 ############################################
 
 
-class DistanceRandomForestBase:
+class DistanceRandomForestBase(ABC):
     """
-    Base class shared by Random-Forest-based proximity distance metrics.
+    Abstract base class shared by Random-Forest-based proximity distance metrics.
 
     Holds the memory-efficient memmap configuration, the ``terminals`` attribute,
     the on-disk allocation helper, and the cleanup logic. Subclasses
     (``DistanceRandomForestProximity``, ``DistanceRandomForestLCA``) implement
     :meth:`calculate_terminals` and :meth:`calculate_distance_matrix` with their
-    own state and numba kernels. This class is not intended for direct
-    instantiation; users should construct one of the concrete subclasses.
+    own state and numba kernels. This class declares those two methods as
+    ``@abstractmethod`` so that the public ``DistanceRandomForestBase`` type used
+    in ``clustering_distance_metric`` / ``distance_metric`` parameters is
+    recognized as exposing them, and so that direct instantiation raises
+    ``TypeError``. Construct one of the concrete subclasses instead.
 
     :param memory_efficient: Whether to store the distance matrix in a disk-backed memmap array.
     :type memory_efficient: bool
@@ -53,6 +57,47 @@ class DistanceRandomForestBase:
         self.memory_efficient = memory_efficient
         self.dir_distance_matrix = dir_distance_matrix
         self.precomputed_distance_matrix = None
+
+    @abstractmethod
+    def calculate_terminals(
+        self,
+        estimator: RandomForestClassifier | RandomForestRegressor,
+        X: pd.DataFrame,
+    ) -> None:
+        """
+        Compute and store the per-sample, per-tree state needed to derive the distance matrix.
+
+        Concrete subclasses populate ``self.terminals`` (and any subclass-specific
+        state, e.g. ``paths`` / ``path_lens`` for ``DistanceRandomForestLCA``) from
+        the trained Random Forest. Must be called before :meth:`calculate_distance_matrix`.
+
+        :param estimator: Trained Random Forest estimator.
+        :type estimator: RandomForestClassifier | RandomForestRegressor
+        :param X: Input feature matrix.
+        :type X: pd.DataFrame
+        :return: ``None``
+        :rtype: None
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def calculate_distance_matrix(
+        self,
+        sample_indices: np.ndarray | None,
+    ) -> tuple[np.ndarray | np.memmap, str | None]:
+        """
+        Compute the pairwise distance matrix from the precomputed per-tree state.
+
+        Concrete subclasses define the actual proximity model (e.g. terminal-node
+        agreement or LCA-depth proximity) and the corresponding numba kernel.
+        Requires :meth:`calculate_terminals` to have been called first.
+
+        :param sample_indices: Indices of the samples for which the distance matrix is computed, or ``None`` to use all samples.
+        :type sample_indices: np.ndarray | None
+        :return: Tuple containing the distance matrix and the memmap file path, or ``None`` as the path when computed fully in memory.
+        :rtype: tuple[np.ndarray | np.memmap, str | None]
+        """
+        raise NotImplementedError
 
     def _allocate_distance_matrix(self, n: int) -> tuple[np.ndarray | np.memmap, str | None]:
         """Allocate an in-memory or memmap-backed (n, n) float32 distance matrix."""

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -25,7 +25,93 @@ from .utils import check_disk_space
 ############################################
 
 
-class DistanceRandomForestProximity:
+class DistanceRandomForestBase:
+    """
+    Base class shared by Random-Forest-based proximity distance metrics.
+
+    Holds the memory-efficient memmap configuration, the ``terminals`` attribute,
+    the on-disk allocation helper, and the cleanup logic. Subclasses
+    (``DistanceRandomForestProximity``, ``DistanceRandomForestLCA``) implement
+    :meth:`calculate_terminals` and :meth:`calculate_distance_matrix` with their
+    own state and numba kernels. This class is not intended for direct
+    instantiation; consumers should construct one of the concrete subclasses.
+
+    :param memory_efficient: Whether to store the distance matrix in a disk-backed memmap array.
+    :type memory_efficient: bool
+    :param dir_distance_matrix: Directory used to store the memmap distance matrix when ``memory_efficient=True``.
+    :type dir_distance_matrix: str | None
+    """
+
+    def __init__(
+        self,
+        memory_efficient: bool = False,
+        dir_distance_matrix: str | None = None,
+    ) -> None:
+        if memory_efficient and dir_distance_matrix is None:
+            raise ValueError(
+                "You must specify `dir_distance_matrix` when `memory_efficient=True`."
+            )
+        self.terminals: np.ndarray | None = None
+        self.memory_efficient = memory_efficient
+        self.dir_distance_matrix = dir_distance_matrix
+        self.precomputed_distance_matrix = None
+
+    def _allocate_distance_matrix(
+        self, n: int
+    ) -> tuple[np.ndarray | np.memmap, str | None]:
+        """Allocate an in-memory or memmap-backed (n, n) float32 distance matrix."""
+        if self.memory_efficient:
+            if self.dir_distance_matrix is None:
+                raise ValueError(
+                    "You must specify `dir_distance_matrix` when `memory_efficient=True`."
+                )
+            buffer_factor = 1.2
+            required_bytes = int(n * n * 4 * buffer_factor)
+            if not check_disk_space(self.dir_distance_matrix, required_bytes):
+                raise MemoryError(
+                    f"Not enough free space to allocate a {required_bytes / 1e9:.2f} GB "
+                    "memmap distance matrix (with 20% buffer)."
+                )
+            file_distance_matrix = os.path.join(
+                self.dir_distance_matrix,
+                f"distance_matrix_{uuid.uuid4().hex[:8]}.dat",
+            )
+            return (
+                np.memmap(
+                    file_distance_matrix,
+                    dtype=np.float32,
+                    mode="w+",
+                    shape=(n, n),
+                ),
+                file_distance_matrix,
+            )
+        return np.zeros((n, n), dtype=np.float32), None
+
+    def remove_distance_matrix(
+        self,
+        distance_matrix: np.ndarray | np.memmap,
+        file_distance_matrix: str | None,
+    ) -> None:
+        """Flush, release, and delete a (possibly memmap) distance matrix."""
+        if isinstance(distance_matrix, np.memmap):
+            try:
+                distance_matrix.flush()
+            except Exception:
+                pass
+        del distance_matrix
+        gc.collect()
+
+        if file_distance_matrix is not None and os.path.exists(file_distance_matrix):
+            for _ in range(3):
+                try:
+                    os.remove(file_distance_matrix)
+                    break
+                except PermissionError:
+                    time.sleep(0.5)
+                    gc.collect()
+
+
+class DistanceRandomForestProximity(DistanceRandomForestBase):
     """
     Compute a proximity-based distance matrix from the terminal nodes of a trained Random Forest model,
     or from a coarser inner-node projection when an ancestor-collapse criterion is provided.
@@ -91,9 +177,10 @@ class DistanceRandomForestProximity:
         min_node_variance: float | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestProximity class."""
-        if memory_efficient:
-            if dir_distance_matrix is None:
-                raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
+        super().__init__(
+            memory_efficient=memory_efficient,
+            dir_distance_matrix=dir_distance_matrix,
+        )
 
         if min_samples_in_node is not None and min_samples_in_node < 1:
             raise ValueError("`min_samples_in_node` must be a positive integer.")
@@ -110,13 +197,9 @@ class DistanceRandomForestProximity:
             min_node_variance=min_node_variance,
         )
 
-        self.terminals: np.ndarray | None = None
-        self.memory_efficient = memory_efficient
-        self.dir_distance_matrix = dir_distance_matrix
         self.min_samples_in_node = min_samples_in_node
         self.max_depth_for_proximity = max_depth_for_proximity
         self.min_node_variance = min_node_variance
-        self.precomputed_distance_matrix = None
 
     def calculate_terminals(
         self,
@@ -251,79 +334,17 @@ class DistanceRandomForestProximity:
         """
         if self.terminals is None:
             raise ValueError(
-                "No precomputed terminals available to compute distance matrix! Run `calculate_terminals()` first."
+                "No precomputed terminals available to compute distance matrix! "
+                "Run `calculate_terminals()` first."
             )
-        else:
-            if sample_indices is not None:
-                terminals = self.terminals[sample_indices]
-            else:
-                terminals = self.terminals
-            n, n_estimators = terminals.shape
-            distance_matrix: np.ndarray | np.memmap
-
-            if self.memory_efficient:
-                if self.dir_distance_matrix is None:
-                    raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
-                buffer_factor = 1.2  # 20% safety buffer
-                required_bytes = int(n * n * 4 * buffer_factor)  # float32 = 4 bytes
-                if not check_disk_space(self.dir_distance_matrix, required_bytes):
-                    raise MemoryError(
-                        f"Not enough free space to allocate a {required_bytes / 1e9:.2f} GB memmap distance matrix (with 20% buffer)."
-                    )
-                file_distance_matrix = os.path.join(
-                    self.dir_distance_matrix,
-                    f"distance_matrix_{uuid.uuid4().hex[:8]}.dat",
-                )
-                distance_matrix = np.memmap(file_distance_matrix, dtype=np.float32, mode="w+", shape=(n, n))
-            else:
-                file_distance_matrix = None
-                distance_matrix = np.zeros((n, n), dtype=np.float32)
-
-            distance_matrix = _calculate_distances(terminals, n, n_estimators, distance_matrix)
-
-            return distance_matrix, file_distance_matrix
-
-    def remove_distance_matrix(
-        self,
-        distance_matrix: np.ndarray | np.memmap,
-        file_distance_matrix: str | None,
-    ) -> None:
-        """
-        Remove a disk-backed distance matrix file and release associated resources.
-
-        If the distance matrix was created as a memmap array, this method attempts to flush
-        pending writes, delete the array object, trigger garbage collection, and remove the
-        backing file from disk. Repeated removal attempts are made to avoid file-locking
-        issues on some systems.
-
-        :param distance_matrix: Distance matrix object to release.
-        :type distance_matrix: np.ndarray | np.memmap
-        :param file_distance_matrix: Path to the memmap file on disk, or ``None`` if no file was created.
-        :type file_distance_matrix: str | None
-
-        :return: ``None``
-        :rtype: None
-        """
-        if isinstance(distance_matrix, np.memmap):
-            try:
-                distance_matrix.flush()
-            except Exception:
-                pass  # Might not always be necessary, but safe to attempt
-
-        del distance_matrix
-        gc.collect()
-
-        if file_distance_matrix is not None and os.path.exists(file_distance_matrix):
-            for _ in range(3):
-                try:
-                    os.remove(file_distance_matrix)
-                    break
-                except PermissionError:
-                    time.sleep(0.5)  # Give OS time to release the file
-                    gc.collect()
+        terminals = self.terminals if sample_indices is None else self.terminals[sample_indices]
+        n, n_estimators = terminals.shape
+        distance_matrix, file_distance_matrix = self._allocate_distance_matrix(n)
+        distance_matrix = _calculate_distances(terminals, n, n_estimators, distance_matrix)
+        return distance_matrix, file_distance_matrix
 
 
-class DistanceRandomForestLCA:
+class DistanceRandomForestLCA(DistanceRandomForestBase):
     """
     Compute a proximity-based distance matrix from the Least Common Ancestor (LCA) depth
     of samples along decision paths of a trained Random Forest model.
@@ -365,16 +386,12 @@ class DistanceRandomForestLCA:
         dir_distance_matrix: str | None = None,
     ) -> None:
         """Constructor for the DistanceRandomForestLCA class."""
-        if memory_efficient:
-            if dir_distance_matrix is None:
-                raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
-
-        self.terminals: np.ndarray | None = None
+        super().__init__(
+            memory_efficient=memory_efficient,
+            dir_distance_matrix=dir_distance_matrix,
+        )
         self.paths: np.ndarray | None = None
         self.path_lens: np.ndarray | None = None
-        self.memory_efficient = memory_efficient
-        self.dir_distance_matrix = dir_distance_matrix
-        self.precomputed_distance_matrix = None
 
     def calculate_terminals(
         self,
@@ -462,64 +479,9 @@ class DistanceRandomForestLCA:
             paths = self.paths
             path_lens = self.path_lens
         n, n_estimators, _ = paths.shape
-        distance_matrix: np.ndarray | np.memmap
-
-        if self.memory_efficient:
-            if self.dir_distance_matrix is None:
-                raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
-            buffer_factor = 1.2
-            required_bytes = int(n * n * 4 * buffer_factor)
-            if not check_disk_space(self.dir_distance_matrix, required_bytes):
-                raise MemoryError(
-                    f"Not enough free space to allocate a {required_bytes / 1e9:.2f} GB memmap distance matrix (with 20% buffer)."
-                )
-            file_distance_matrix = os.path.join(
-                self.dir_distance_matrix, f"distance_matrix_{uuid.uuid4().hex[:8]}.dat"
-            )
-            distance_matrix = np.memmap(file_distance_matrix, dtype=np.float32, mode="w+", shape=(n, n))
-        else:
-            file_distance_matrix = None
-            distance_matrix = np.zeros((n, n), dtype=np.float32)
-
+        distance_matrix, file_distance_matrix = self._allocate_distance_matrix(n)
         distance_matrix = _calculate_lca_distances(paths, path_lens, n, n_estimators, distance_matrix)
-
         return distance_matrix, file_distance_matrix
-
-    def remove_distance_matrix(
-        self,
-        distance_matrix: np.ndarray | np.memmap,
-        file_distance_matrix: str | None,
-    ) -> None:
-        """
-        Remove a disk-backed distance matrix file and release associated resources.
-
-        Behavior mirrors :meth:`DistanceRandomForestProximity.remove_distance_matrix`.
-
-        :param distance_matrix: Distance matrix object to release.
-        :type distance_matrix: np.ndarray | np.memmap
-        :param file_distance_matrix: Path to the memmap file on disk, or ``None`` if no file was created.
-        :type file_distance_matrix: str | None
-
-        :return: ``None``
-        :rtype: None
-        """
-        if isinstance(distance_matrix, np.memmap):
-            try:
-                distance_matrix.flush()
-            except Exception:
-                pass
-
-        del distance_matrix
-        gc.collect()
-
-        if file_distance_matrix is not None and os.path.exists(file_distance_matrix):
-            for _ in range(3):
-                try:
-                    os.remove(file_distance_matrix)
-                    break
-                except PermissionError:
-                    time.sleep(0.5)
-                    gc.collect()
 
 
 class DistanceWasserstein:

--- a/fgclustering/distance.py
+++ b/fgclustering/distance.py
@@ -34,7 +34,7 @@ class DistanceRandomForestBase:
     (``DistanceRandomForestProximity``, ``DistanceRandomForestLCA``) implement
     :meth:`calculate_terminals` and :meth:`calculate_distance_matrix` with their
     own state and numba kernels. This class is not intended for direct
-    instantiation; consumers should construct one of the concrete subclasses.
+    instantiation; users should construct one of the concrete subclasses.
 
     :param memory_efficient: Whether to store the distance matrix in a disk-backed memmap array.
     :type memory_efficient: bool
@@ -48,23 +48,17 @@ class DistanceRandomForestBase:
         dir_distance_matrix: str | None = None,
     ) -> None:
         if memory_efficient and dir_distance_matrix is None:
-            raise ValueError(
-                "You must specify `dir_distance_matrix` when `memory_efficient=True`."
-            )
+            raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
         self.terminals: np.ndarray | None = None
         self.memory_efficient = memory_efficient
         self.dir_distance_matrix = dir_distance_matrix
         self.precomputed_distance_matrix = None
 
-    def _allocate_distance_matrix(
-        self, n: int
-    ) -> tuple[np.ndarray | np.memmap, str | None]:
+    def _allocate_distance_matrix(self, n: int) -> tuple[np.ndarray | np.memmap, str | None]:
         """Allocate an in-memory or memmap-backed (n, n) float32 distance matrix."""
         if self.memory_efficient:
             if self.dir_distance_matrix is None:
-                raise ValueError(
-                    "You must specify `dir_distance_matrix` when `memory_efficient=True`."
-                )
+                raise ValueError("You must specify `dir_distance_matrix` when `memory_efficient=True`.")
             buffer_factor = 1.2
             required_bytes = int(n * n * 4 * buffer_factor)
             if not check_disk_space(self.dir_distance_matrix, required_bytes):

--- a/fgclustering/forest_guided_clustering.py
+++ b/fgclustering/forest_guided_clustering.py
@@ -17,7 +17,7 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from .utils import check_input_data, check_input_estimator, check_sub_sample_size, check_k_range
 from .clustering import ClusteringKMedoids, ClusteringClara
-from .distance import DistanceWasserstein, DistanceJensenShannon, DistanceRandomForestProximity
+from .distance import DistanceWasserstein, DistanceJensenShannon, DistanceRandomForestBase
 from .optimizer import Optimizer
 from .statistics import FeatureImportance
 from .plotting import (
@@ -50,7 +50,7 @@ def forest_guided_clustering(
     estimator: RandomForestClassifier | RandomForestRegressor,
     X: pd.DataFrame,
     y: str | pd.Series,
-    clustering_distance_metric: DistanceRandomForestProximity,
+    clustering_distance_metric: DistanceRandomForestBase,
     clustering_strategy: ClusteringKMedoids | ClusteringClara,
     k: int | tuple[int, int] | None = None,
     JI_bootstrap_iter: int = 100,
@@ -78,7 +78,7 @@ def forest_guided_clustering(
     :param y: Target variable, given either as target values or as the name of the target column in ``X``.
     :type y: str | pd.Series
     :param clustering_distance_metric: Distance metric based on Random Forest terminal-node proximity.
-    :type clustering_distance_metric: DistanceRandomForestProximity
+    :type clustering_distance_metric: DistanceRandomForestBase
     :param clustering_strategy: Clustering strategy used to group samples from the distance matrix.
     :type clustering_strategy: ClusteringKMedoids | ClusteringClara
     :param k: Number of clusters if given as an integer, optimization range if given as ``(min_k, max_k)``, or ``None`` to use the default range ``(2, 6)``.

--- a/fgclustering/forest_guided_clustering.py
+++ b/fgclustering/forest_guided_clustering.py
@@ -77,7 +77,7 @@ def forest_guided_clustering(
     :type X: pd.DataFrame
     :param y: Target variable, given either as target values or as the name of the target column in ``X``.
     :type y: str | pd.Series
-    :param clustering_distance_metric: Distance metric based on Random Forest terminal-node proximity.
+    :param clustering_distance_metric: Random-Forest-based distance metric used to compute pairwise sample distances, such as terminal-node proximity or other supported forest-derived distances.
     :type clustering_distance_metric: DistanceRandomForestBase
     :param clustering_strategy: Clustering strategy used to group samples from the distance matrix.
     :type clustering_strategy: ClusteringKMedoids | ClusteringClara

--- a/fgclustering/optimizer.py
+++ b/fgclustering/optimizer.py
@@ -13,7 +13,7 @@ from collections import defaultdict, Counter
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from .utils import map_clusters_to_samples
-from .distance import DistanceRandomForestProximity
+from .distance import DistanceRandomForestBase
 from .clustering import ClusteringKMedoids, ClusteringClara
 
 
@@ -34,7 +34,7 @@ class Optimizer:
     stable clustering with the best quality score.
 
     :param distance_metric: Distance metric based on Random Forest proximity.
-    :type distance_metric: DistanceRandomForestProximity
+    :type distance_metric: DistanceRandomForestBase
     :param clustering_strategy: Clustering strategy used to generate cluster assignments.
     :type clustering_strategy: ClusteringKMedoids | ClusteringClara
     :param random_state: Random seed used for reproducibility.
@@ -43,7 +43,7 @@ class Optimizer:
 
     def __init__(
         self,
-        distance_metric: DistanceRandomForestProximity,
+        distance_metric: DistanceRandomForestBase,
         clustering_strategy: ClusteringKMedoids | ClusteringClara,
         random_state: int | None,
     ):

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -10,18 +10,46 @@ import pandas as pd
 
 from pathlib import Path
 
-from sklearn.datasets import make_classification
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import make_classification, make_regression
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from fgclustering.distance import (
+    DistanceRandomForestLCA,
     DistanceRandomForestProximity,
     DistanceWasserstein,
     DistanceJensenShannon,
+    _build_leaf_to_ancestor_map,
+    _calculate_lca_distances,
+    _compute_node_depths,
+    _compute_parent_array,
+    _validate_mutually_exclusive,
 )
 
 ############################################
 # Tests
 ############################################
+
+
+def _build_regression_forest(
+    random_state=42,
+    criterion="squared_error",
+    n_estimators=20,
+    max_depth=8,
+):
+    X, y = make_regression(
+        n_samples=50,
+        n_features=5,
+        n_informative=3,
+        random_state=random_state,
+    )
+    X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+    model = RandomForestRegressor(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        criterion=criterion,
+        random_state=random_state,
+    ).fit(X, y)
+    return X, y, model
 
 
 class TestDistanceRandomForestProximity(unittest.TestCase):
@@ -61,24 +89,10 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         return X, y, model
 
     def _train_regression_model(self, criterion="squared_error"):
-        from sklearn.datasets import make_regression
-        from sklearn.ensemble import RandomForestRegressor
-
-        X, y = make_regression(
-            n_samples=50,
-            n_features=5,
-            n_informative=3,
+        return _build_regression_forest(
             random_state=self.random_state,
-        )
-        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        model = RandomForestRegressor(
-            n_estimators=20,
-            max_depth=8,
             criterion=criterion,
-            random_state=self.random_state,
         )
-        model.fit(X=X, y=y)
-        return X, y, model
 
     def tearDown(self):
         try:
@@ -89,28 +103,28 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_calculate_terminals(self):
         dist = DistanceRandomForestProximity()
         dist.calculate_terminals(estimator=self.model, X=self.X)
-        self.assertIsNotNone(obj=dist.terminals)
-        self.assertEqual(first=dist.terminals.shape[0], second=self.X.shape[0])
+        self.assertIsNotNone(dist.terminals)
+        self.assertEqual(dist.terminals.shape[0], self.X.shape[0])
 
     def test_calculate_distance_matrix_non_memory_efficient(self):
         dist = DistanceRandomForestProximity(memory_efficient=False)
         dist.calculate_terminals(estimator=self.model, X=self.X)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(first=matrix.shape[0], second=matrix.shape[1])
-        self.assertEqual(first=matrix.shape[0], second=len(self.X))
-        self.assertTrue(expr=np.allclose(a=matrix, b=matrix.T))
-        self.assertTrue(expr=np.all(a=np.diag(v=matrix) == 0))
-        self.assertTrue(expr=file is None)
+        self.assertEqual(matrix.shape[0], matrix.shape[1])
+        self.assertEqual(matrix.shape[0], len(self.X))
+        self.assertTrue(np.allclose(matrix, matrix.T))
+        self.assertTrue(np.all(np.diag(matrix) == 0))
+        self.assertTrue(file is None)
 
     def test_calculate_distance_matrix_memory_efficient(self):
         dist = DistanceRandomForestProximity(memory_efficient=True, dir_distance_matrix=self.tmp_path)
         dist.calculate_terminals(estimator=self.model, X=self.X)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
         self.assertTrue(isinstance(matrix, np.memmap))
-        self.assertEqual(first=matrix.shape[0], second=matrix.shape[1])
-        self.assertTrue(expr=np.allclose(a=matrix, b=matrix.T))
-        self.assertTrue(expr=np.all(a=np.diag(v=matrix) == 0))
-        self.assertTrue(expr=os.path.exists(path=file))
+        self.assertEqual(matrix.shape[0], matrix.shape[1])
+        self.assertTrue(np.allclose(matrix, matrix.T))
+        self.assertTrue(np.all(np.diag(matrix) == 0))
+        self.assertTrue(os.path.exists(file))
 
     def test_calculate_distance_matrix_error_without_terminals(self):
         dist = DistanceRandomForestProximity()
@@ -124,9 +138,9 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_calculate_distance_matrix_with_sample_indices(self):
         dist = DistanceRandomForestProximity(memory_efficient=False)
         dist.calculate_terminals(estimator=self.model, X=self.X)
-        sample_indices = np.random.choice(a=len(self.X), size=20, replace=False)
+        sample_indices = np.random.choice(len(self.X), size=20, replace=False)
         matrix, file = dist.calculate_distance_matrix(sample_indices=sample_indices)
-        self.assertEqual(first=matrix.shape, second=(20, 20))
+        self.assertEqual(matrix.shape, (20, 20))
 
     def test_min_samples_in_node_none_matches_baseline(self):
         """Default behavior (min_samples_in_node=None) must match pre-feature output."""
@@ -151,6 +165,16 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_min_samples_in_node_baseline_on_regressor(self):
+        X_reg, _, model_reg = _build_regression_forest()
+        baseline = DistanceRandomForestProximity()
+        baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        bm, _ = baseline.calculate_distance_matrix(sample_indices=None)
+        new = DistanceRandomForestProximity(min_samples_in_node=1)
+        new.calculate_terminals(estimator=model_reg, X=X_reg)
+        nm, _ = new.calculate_distance_matrix(sample_indices=None)
+        np.testing.assert_array_equal(bm, nm)
 
     def test_min_samples_in_node_large_collapses_to_root(self):
         """A threshold larger than any node forces every leaf to the root -> all zeros."""
@@ -219,6 +243,16 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
+
+    def test_max_depth_for_proximity_baseline_on_regressor(self):
+        X_reg, _, model_reg = _build_regression_forest()
+        baseline = DistanceRandomForestProximity()
+        baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        bm, _ = baseline.calculate_distance_matrix(sample_indices=None)
+        new = DistanceRandomForestProximity(max_depth_for_proximity=10_000)
+        new.calculate_terminals(estimator=model_reg, X=X_reg)
+        nm, _ = new.calculate_distance_matrix(sample_indices=None)
+        np.testing.assert_array_equal(bm, nm)
 
     def test_max_depth_for_proximity_monotonicity(self):
         """Mean off-diagonal distance is non-decreasing as the depth threshold grows."""
@@ -376,22 +410,9 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
         self.X, self.y, self.model = self._train_regression_model()
 
     def _train_regression_model(self):
-        from sklearn.datasets import make_regression
-        from sklearn.ensemble import RandomForestRegressor
-
-        X, y = make_regression(
-            n_samples=50,
-            n_features=5,
-            n_informative=3,
+        X, y, model = _build_regression_forest(
             random_state=self.random_state,
         )
-        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        model = RandomForestRegressor(
-            n_estimators=20,
-            max_depth=8,
-            random_state=self.random_state,
-        )
-        model.fit(X=X, y=y)
         return X, y, model
 
     def tearDown(self):
@@ -401,8 +422,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
             pass
 
     def test_calculate_terminals_populates_state(self):
-        from fgclustering.distance import DistanceRandomForestLCA, _compute_node_depths
-
         dist = DistanceRandomForestLCA()
         dist.calculate_terminals(estimator=self.model, X=self.X)
         self.assertIsNotNone(dist.terminals)
@@ -420,8 +439,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
             np.testing.assert_array_equal(dist.path_lens[:, t], expected_lens)
 
     def test_calculate_distance_matrix_shape_symmetry_and_diagonal(self):
-        from fgclustering.distance import DistanceRandomForestLCA
-
         dist = DistanceRandomForestLCA()
         dist.calculate_terminals(estimator=self.model, X=self.X)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
@@ -432,8 +449,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_same_leaf_samples_have_zero_distance(self):
         """Samples that share the same leaf in every tree must have distance 0."""
-        from fgclustering.distance import DistanceRandomForestLCA
-
         dist = DistanceRandomForestLCA()
         dist.calculate_terminals(estimator=self.model, X=self.X)
         same_terminals = (dist.terminals[:, None, :] == dist.terminals[None, :, :]).all(axis=2)
@@ -441,8 +456,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
         self.assertTrue(np.all(matrix[same_terminals] == 0.0))
 
     def test_memory_efficient_memmap_path_matches_in_memory(self):
-        from fgclustering.distance import DistanceRandomForestLCA
-
         d1 = DistanceRandomForestLCA(memory_efficient=False)
         d1.calculate_terminals(estimator=self.model, X=self.X)
         m1, _ = d1.calculate_distance_matrix(sample_indices=None)
@@ -459,21 +472,15 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
         self.assertFalse(os.path.exists(f2))
 
     def test_calculate_distance_matrix_error_without_paths(self):
-        from fgclustering.distance import DistanceRandomForestLCA
-
         dist = DistanceRandomForestLCA()
         with self.assertRaises(ValueError):
             dist.calculate_distance_matrix(sample_indices=None)
 
     def test_init_missing_dir_in_memory_efficient_mode(self):
-        from fgclustering.distance import DistanceRandomForestLCA
-
         with self.assertRaises(ValueError):
             DistanceRandomForestLCA(memory_efficient=True)
 
     def test_sample_indices_slicing(self):
-        from fgclustering.distance import DistanceRandomForestLCA
-
         dist = DistanceRandomForestLCA()
         dist.calculate_terminals(estimator=self.model, X=self.X)
         idx = np.random.RandomState(0).choice(len(self.X), size=20, replace=False)
@@ -483,8 +490,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_lca_distance_increases_when_deeper_path_is_grown(self):
         """Growing the deeper path lowers similarity and increases distance under max-based normalization."""
-        from fgclustering.distance import _calculate_lca_distances
-
         n_trees = 1
 
         def run(paths_list, lens_list):
@@ -504,8 +509,6 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_lca_distance_root_only_trees_are_treated_as_identical(self):
         """Both samples at depth 0 fall back to similarity 1.0."""
-        from fgclustering.distance import _calculate_lca_distances
-
         paths = np.full((2, 1, 1), -1, dtype=np.int32)
         paths[0, 0, 0] = 0
         paths[1, 0, 0] = 0
@@ -513,6 +516,73 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
         out = np.zeros((2, 2), dtype=np.float32)
         result = _calculate_lca_distances(paths, lens, 2, 1, out)
         self.assertEqual(float(result[0, 1]), 0.0)
+
+    def test_lca_distance_le_terminal_distance(self):
+        """Per-pair invariant: LCA distance ≤ terminal-node distance."""
+        proximity = DistanceRandomForestProximity()
+        proximity.calculate_terminals(estimator=self.model, X=self.X)
+        pm, _ = proximity.calculate_distance_matrix(sample_indices=None)
+
+        lca = DistanceRandomForestLCA()
+        lca.calculate_terminals(estimator=self.model, X=self.X)
+        lm, _ = lca.calculate_distance_matrix(sample_indices=None)
+
+        self.assertTrue(np.all(np.asarray(lm) <= np.asarray(pm) + 1e-6))
+
+
+class TestTreeHelpers(unittest.TestCase):
+    """Direct unit tests for the tree-walking helpers."""
+
+    def setUp(self):
+        X, y = make_classification(n_samples=30, n_features=4, random_state=0)
+        self.tree = (
+            RandomForestClassifier(n_estimators=1, max_depth=3, random_state=0)
+            .fit(X, y)
+            .estimators_[0]
+            .tree_
+        )
+
+    def test_compute_parent_array_root_is_minus_one(self):
+        parent = _compute_parent_array(self.tree)
+        self.assertEqual(parent[0], -1)
+
+    def test_compute_parent_array_each_non_root_has_a_parent(self):
+        parent = _compute_parent_array(self.tree)
+        for n in range(1, self.tree.node_count):
+            self.assertGreaterEqual(parent[n], 0)
+            self.assertLess(parent[n], self.tree.node_count)
+
+    def test_compute_node_depths_root_is_zero_and_increases(self):
+        depths = _compute_node_depths(self.tree)
+        self.assertEqual(depths[0], 0)
+        for n in range(self.tree.node_count):
+            left = self.tree.children_left[n]
+            right = self.tree.children_right[n]
+            if left != -1:
+                self.assertEqual(depths[left], depths[n] + 1)
+            if right != -1:
+                self.assertEqual(depths[right], depths[n] + 1)
+
+    def test_build_leaf_to_ancestor_map_predicate_always_true(self):
+        parent = _compute_parent_array(self.tree)
+        leaf_map = _build_leaf_to_ancestor_map(self.tree, parent, lambda _: True)
+        for n in range(self.tree.node_count):
+            if self.tree.children_left[n] == -1:
+                self.assertEqual(leaf_map[n], n)
+
+    def test_build_leaf_to_ancestor_map_predicate_always_false(self):
+        parent = _compute_parent_array(self.tree)
+        leaf_map = _build_leaf_to_ancestor_map(self.tree, parent, lambda _: False)
+        for n in range(self.tree.node_count):
+            if self.tree.children_left[n] == -1:
+                self.assertEqual(leaf_map[n], 0)
+
+    def test_validate_mutually_exclusive_single_ok(self):
+        _validate_mutually_exclusive(a=1, b=None, c=None)
+
+    def test_validate_mutually_exclusive_two_raises(self):
+        with self.assertRaises(ValueError):
+            _validate_mutually_exclusive(a=1, b=2, c=None)
 
 
 class TestDistanceWasserstein(unittest.TestCase):

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -52,6 +52,34 @@ def _build_regression_forest(
     return X, y, model
 
 
+def _build_classification_forest(
+    random_state=42,
+    max_depth=10,
+    max_features="sqrt",
+    max_samples=0.8,
+    bootstrap=True,
+    oob_score=True,
+):
+    # Generate test data
+    X, y = make_classification(
+        n_samples=50,
+        n_features=5,
+        n_informative=3,
+        n_redundant=1,
+        random_state=random_state,
+    )
+    X = pd.DataFrame(data=X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+    model = RandomForestClassifier(
+        max_depth=max_depth,
+        max_features=max_features,
+        max_samples=max_samples,
+        bootstrap=bootstrap,
+        oob_score=oob_score,
+        random_state=random_state,
+    ).fit(X, y)
+    return X, y, model
+
+
 class TestDistanceRandomForestProximity(unittest.TestCase):
     def setUp(self):
         self.tmp_path = os.path.join(os.getcwd(), "tmp_fgc")
@@ -61,32 +89,21 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         self.n_jobs = 2
         self.verbose = 1
 
-        self.X, self.y, self.model = self._train_model()
+        self.X_clas, self.y_clas, self.model_clas = self._train_classification_model()
+        self.X_reg_squared, self.y_reg_squared, self.model_reg_squared = self._train_regression_model(
+            criterion="squared_error"
+        )
+        self.X_reg_friedman, self.y_reg_friedman, self.model_reg_friedman = self._train_regression_model(
+            criterion="friedman_mse"
+        )
+        self.X_reg_absolute, self.y_reg_absolute, self.model_reg_absolute = self._train_regression_model(
+            criterion="absolute_error"
+        )
 
-    def _train_model(self):
-
-        # Generate test data
-        X, y = make_classification(
-            n_samples=50,
-            n_features=5,
-            n_informative=3,
-            n_redundant=1,
+    def _train_classification_model(self):
+        return _build_classification_forest(
             random_state=self.random_state,
         )
-        X = pd.DataFrame(data=X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        y = y
-
-        model = RandomForestClassifier(
-            max_depth=10,
-            max_features="sqrt",
-            max_samples=0.8,
-            bootstrap=True,
-            oob_score=True,
-            random_state=self.random_state,
-        )
-        model.fit(X=X, y=y)
-
-        return X, y, model
 
     def _train_regression_model(self, criterion="squared_error"):
         return _build_regression_forest(
@@ -102,23 +119,23 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
 
     def test_calculate_terminals(self):
         dist = DistanceRandomForestProximity()
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         self.assertIsNotNone(dist.terminals)
-        self.assertEqual(dist.terminals.shape[0], self.X.shape[0])
+        self.assertEqual(dist.terminals.shape[0], self.X_clas.shape[0])
 
     def test_calculate_distance_matrix_non_memory_efficient(self):
         dist = DistanceRandomForestProximity(memory_efficient=False)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
         self.assertEqual(matrix.shape[0], matrix.shape[1])
-        self.assertEqual(matrix.shape[0], len(self.X))
+        self.assertEqual(matrix.shape[0], len(self.X_clas))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
         self.assertTrue(file is None)
 
     def test_calculate_distance_matrix_memory_efficient(self):
         dist = DistanceRandomForestProximity(memory_efficient=True, dir_distance_matrix=self.tmp_path)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
         self.assertTrue(isinstance(matrix, np.memmap))
         self.assertEqual(matrix.shape[0], matrix.shape[1])
@@ -137,19 +154,19 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
 
     def test_calculate_distance_matrix_with_sample_indices(self):
         dist = DistanceRandomForestProximity(memory_efficient=False)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
-        sample_indices = np.random.choice(len(self.X), size=20, replace=False)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
+        sample_indices = np.random.choice(len(self.X_clas), size=20, replace=False)
         matrix, file = dist.calculate_distance_matrix(sample_indices=sample_indices)
         self.assertEqual(matrix.shape, (20, 20))
 
     def test_min_samples_in_node_none_matches_baseline(self):
         """Default behavior (min_samples_in_node=None) must match pre-feature output."""
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        dist_baseline.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(min_samples_in_node=None)
-        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        dist_new.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
@@ -157,45 +174,31 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_min_samples_in_node_one_matches_baseline(self):
         """A threshold of 1 must be a no-op: every leaf already has >=1 sample."""
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        dist_baseline.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(min_samples_in_node=1)
-        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        dist_new.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_min_samples_in_node_baseline_on_regressor(self):
-        X_reg, _, model_reg = _build_regression_forest()
         baseline = DistanceRandomForestProximity()
-        baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        baseline.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         bm, _ = baseline.calculate_distance_matrix(sample_indices=None)
+
         new = DistanceRandomForestProximity(min_samples_in_node=1)
-        new.calculate_terminals(estimator=model_reg, X=X_reg)
+        new.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         nm, _ = new.calculate_distance_matrix(sample_indices=None)
         np.testing.assert_array_equal(bm, nm)
 
     def test_min_samples_in_node_large_collapses_to_root(self):
         """A threshold larger than any node forces every leaf to the root -> all zeros."""
-        huge = 10 * len(self.X)
+        huge = 10 * len(self.X_clas)
         dist = DistanceRandomForestProximity(min_samples_in_node=huge)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertTrue(np.all(matrix == 0.0))
-
-    def test_min_samples_in_node_monotonicity(self):
-        """Mean off-diagonal distance is non-increasing as the threshold grows."""
-        means = []
-        for threshold in [1, 3, 5, 10, 25]:
-            dist = DistanceRandomForestProximity(min_samples_in_node=threshold)
-            dist.calculate_terminals(estimator=self.model, X=self.X)
-            matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-            n = matrix.shape[0]
-            off_diag = matrix[~np.eye(n, dtype=bool)]
-            means.append(off_diag.mean())
-        for first, second in zip(means, means[1:]):
-            self.assertLessEqual(second, first + 1e-8)
 
     def test_min_samples_in_node_invalid_raises(self):
         """Zero / negative thresholds are rejected at construction."""
@@ -207,20 +210,20 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_min_samples_in_node_preserves_shape_and_symmetry(self):
         """Collapsed matrix keeps the symmetric / zero-diagonal contract."""
         dist = DistanceRandomForestProximity(min_samples_in_node=5)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(matrix.shape, (len(self.X), len(self.X)))
+        self.assertEqual(matrix.shape, (len(self.X_clas), len(self.X_clas)))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
 
     def test_max_depth_for_proximity_none_matches_baseline(self):
         """Default behavior (max_depth_for_proximity=None) must match pre-feature output."""
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        dist_baseline.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(max_depth_for_proximity=None)
-        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        dist_new.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
@@ -228,44 +231,31 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_max_depth_for_proximity_zero_collapses_to_root(self):
         """A threshold of 0 forces every leaf to the root -> distance matrix is all zeros."""
         dist = DistanceRandomForestProximity(max_depth_for_proximity=0)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertTrue(np.all(matrix == 0.0))
 
     def test_max_depth_for_proximity_large_matches_baseline(self):
         """A very large threshold leaves every leaf untouched -> identical to baseline."""
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=self.model, X=self.X)
+        dist_baseline.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(max_depth_for_proximity=10_000)
-        dist_new.calculate_terminals(estimator=self.model, X=self.X)
+        dist_new.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
-    def test_max_depth_for_proximity_baseline_on_regressor(self):
-        X_reg, _, model_reg = _build_regression_forest()
         baseline = DistanceRandomForestProximity()
-        baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        baseline.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         bm, _ = baseline.calculate_distance_matrix(sample_indices=None)
-        new = DistanceRandomForestProximity(max_depth_for_proximity=10_000)
-        new.calculate_terminals(estimator=model_reg, X=X_reg)
-        nm, _ = new.calculate_distance_matrix(sample_indices=None)
-        np.testing.assert_array_equal(bm, nm)
 
-    def test_max_depth_for_proximity_monotonicity(self):
-        """Mean off-diagonal distance is non-decreasing as the depth threshold grows."""
-        means = []
-        for threshold in [0, 1, 2, 3, 5, 10, 100]:
-            dist = DistanceRandomForestProximity(max_depth_for_proximity=threshold)
-            dist.calculate_terminals(estimator=self.model, X=self.X)
-            matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-            n = matrix.shape[0]
-            off_diag = matrix[~np.eye(n, dtype=bool)]
-            means.append(float(off_diag.mean()))
-        for a, b in zip(means, means[1:]):
-            self.assertGreaterEqual(b, a - 1e-8)
+        new = DistanceRandomForestProximity(max_depth_for_proximity=10_000)
+        new.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
+        nm, _ = new.calculate_distance_matrix(sample_indices=None)
+
+        np.testing.assert_array_equal(bm, nm)
 
     def test_max_depth_for_proximity_invalid_raises(self):
         """Negative thresholds are rejected at construction; 0 is allowed."""
@@ -276,54 +266,42 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
     def test_max_depth_for_proximity_preserves_shape_and_symmetry(self):
         """Collapsed matrix keeps the symmetric / zero-diagonal contract."""
         dist = DistanceRandomForestProximity(max_depth_for_proximity=3)
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(matrix.shape, (len(self.X), len(self.X)))
+        self.assertEqual(matrix.shape, (len(self.X_clas), len(self.X_clas)))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
 
-    def test_min_samples_and_max_depth_mutually_exclusive(self):
-        """Setting both ancestor-collapse parameters at once must raise ValueError."""
-        with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(
-                min_samples_in_node=5,
-                max_depth_for_proximity=3,
-            )
-
     def test_min_node_variance_none_matches_baseline(self):
         """Default behavior (min_node_variance=None) on a regressor matches baseline."""
-        X_reg, _, model_reg = self._train_regression_model()
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist_baseline.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(min_node_variance=None)
-        dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist_new.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
     def test_min_node_variance_zero_matches_baseline(self):
         """`min_node_variance=0` prunes nothing (every node has impurity >= 0) -> baseline."""
-        X_reg, _, model_reg = self._train_regression_model()
-
         dist_baseline = DistanceRandomForestProximity()
-        dist_baseline.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist_baseline.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         baseline_matrix, _ = dist_baseline.calculate_distance_matrix(sample_indices=None)
 
         dist_new = DistanceRandomForestProximity(min_node_variance=0.0)
-        dist_new.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist_new.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         new_matrix, _ = dist_new.calculate_distance_matrix(sample_indices=None)
 
         np.testing.assert_array_equal(baseline_matrix, new_matrix)
 
     def test_min_node_variance_large_collapses_to_root(self):
         """A very large variance threshold collapses any leaf to the root."""
-        X_reg, _, model_reg = self._train_regression_model()
         dist = DistanceRandomForestProximity(min_node_variance=10_000.0)
-        dist.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
+        self.assertEqual(matrix.shape, (len(self.X_reg_squared), len(self.X_reg_squared)))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
         self.assertGreaterEqual(matrix.min(), 0.0 - 1e-6)
@@ -333,15 +311,14 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         """Using min_node_variance with a classifier raises ValueError at calculate_terminals."""
         dist = DistanceRandomForestProximity(min_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
-            dist.calculate_terminals(estimator=self.model, X=self.X)
+            dist.calculate_terminals(estimator=self.model_clas, X=self.X_clas)
         self.assertIn("RandomForestRegressor", str(ctx.exception))
 
     def test_min_node_variance_rejects_absolute_error_criterion(self):
         """Using min_node_variance with criterion 'absolute_error' raises ValueError."""
-        X_reg, _, model_reg = self._train_regression_model(criterion="absolute_error")
         dist = DistanceRandomForestProximity(min_node_variance=1.0)
         with self.assertRaises(ValueError) as ctx:
-            dist.calculate_terminals(estimator=model_reg, X=X_reg)
+            dist.calculate_terminals(estimator=self.model_reg_absolute, X=self.X_reg_absolute)
         self.assertIn("squared_error", str(ctx.exception))
         self.assertIn("friedman_mse", str(ctx.exception))
 
@@ -351,30 +328,12 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
             DistanceRandomForestProximity(min_node_variance=-0.5)
         DistanceRandomForestProximity(min_node_variance=0.0)
 
-    def test_min_node_variance_mutually_exclusive_with_min_samples(self):
-        with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(min_samples_in_node=5, min_node_variance=1.0)
-
-    def test_min_node_variance_mutually_exclusive_with_max_depth(self):
-        with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(max_depth_for_proximity=3, min_node_variance=1.0)
-
-    def test_min_node_variance_all_three_mutually_exclusive(self):
-        """Setting any two of the three collapse params at once must raise."""
-        with self.assertRaises(ValueError):
-            DistanceRandomForestProximity(
-                min_samples_in_node=5,
-                max_depth_for_proximity=3,
-                min_node_variance=1.0,
-            )
-
     def test_min_node_variance_preserves_shape_and_symmetry(self):
         """Collapsed matrix keeps the symmetric / zero-diagonal contract on a regressor."""
-        X_reg, _, model_reg = self._train_regression_model()
         dist = DistanceRandomForestProximity(min_node_variance=0.5)
-        dist.calculate_terminals(estimator=model_reg, X=X_reg)
+        dist.calculate_terminals(estimator=self.model_reg_squared, X=self.X_reg_squared)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(matrix.shape, (len(X_reg), len(X_reg)))
+        self.assertEqual(matrix.shape, (len(self.X_reg_squared), len(self.X_reg_squared)))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
 
@@ -382,12 +341,11 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
         """Using min_node_variance with criterion='friedman_mse' must warn and complete."""
         import warnings
 
-        X_reg, _, model_reg = self._train_regression_model(criterion="friedman_mse")
         dist = DistanceRandomForestProximity(min_node_variance=1.0)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            dist.calculate_terminals(estimator=model_reg, X=X_reg)
+            dist.calculate_terminals(estimator=self.model_reg_friedman, X=self.X_reg_friedman)
 
         matched = [
             w for w in caught if issubclass(w.category, UserWarning) and "friedman_mse" in str(w.message)
@@ -398,7 +356,30 @@ class TestDistanceRandomForestProximity(unittest.TestCase):
             msg=f"Expected exactly one friedman_mse UserWarning, got {len(matched)}",
         )
         self.assertIsNotNone(dist.terminals)
-        self.assertEqual(dist.terminals.shape, (len(X_reg), model_reg.n_estimators))
+        self.assertEqual(
+            dist.terminals.shape, (len(self.X_reg_friedman), self.model_reg_friedman.n_estimators)
+        )
+
+    def test_min_samples_mutually_exclusive_with_max_depth(self):
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(min_samples_in_node=5, max_depth_for_proximity=3)
+
+    def test_min_samples_mutually_exclusive_with_min_node_variance(self):
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(min_samples_in_node=5, min_node_variance=1.0)
+
+    def test_max_depth_mutually_exclusive_with_min_node_variance(self):
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(max_depth_for_proximity=3, min_node_variance=1.0)
+
+    def test_all_three_mutually_exclusive(self):
+        """Setting any two of the three collapse params at once must raise."""
+        with self.assertRaises(ValueError):
+            DistanceRandomForestProximity(
+                min_samples_in_node=5,
+                max_depth_for_proximity=3,
+                min_node_variance=1.0,
+            )
 
 
 class TestDistanceRandomForestLCA(unittest.TestCase):
@@ -407,13 +388,13 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
         Path(self.tmp_path).mkdir(parents=True, exist_ok=True)
 
         self.random_state = 42
-        self.X, self.y, self.model = self._train_regression_model()
+        self.X_reg, self.y_reg, self.model_reg = self._train_regression_model()
 
-    def _train_regression_model(self):
-        X, y, model = _build_regression_forest(
+    def _train_regression_model(self, criterion="squared_error"):
+        return _build_regression_forest(
             random_state=self.random_state,
+            criterion=criterion,
         )
-        return X, y, model
 
     def tearDown(self):
         try:
@@ -423,16 +404,16 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_calculate_terminals_populates_state(self):
         dist = DistanceRandomForestLCA()
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         self.assertIsNotNone(dist.terminals)
         self.assertIsNotNone(dist.paths)
         self.assertIsNotNone(dist.path_lens)
-        self.assertEqual(dist.terminals.shape, (len(self.X), self.model.n_estimators))
-        self.assertEqual(dist.paths.shape[0], len(self.X))
-        self.assertEqual(dist.paths.shape[1], self.model.n_estimators)
-        self.assertEqual(dist.path_lens.shape, (len(self.X), self.model.n_estimators))
+        self.assertEqual(dist.terminals.shape, (len(self.X_reg), self.model_reg.n_estimators))
+        self.assertEqual(dist.paths.shape[0], len(self.X_reg))
+        self.assertEqual(dist.paths.shape[1], self.model_reg.n_estimators)
+        self.assertEqual(dist.path_lens.shape, (len(self.X_reg), self.model_reg.n_estimators))
         self.assertTrue(np.all(dist.paths[:, :, 0] == 0))
-        for t, dt in enumerate(self.model.estimators_):
+        for t, dt in enumerate(self.model_reg.estimators_):
             tree = dt.tree_
             depths = _compute_node_depths(tree)
             expected_lens = depths[dist.terminals[:, t]] + 1
@@ -440,9 +421,9 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_calculate_distance_matrix_shape_symmetry_and_diagonal(self):
         dist = DistanceRandomForestLCA()
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         matrix, file = dist.calculate_distance_matrix(sample_indices=None)
-        self.assertEqual(matrix.shape, (len(self.X), len(self.X)))
+        self.assertEqual(matrix.shape, (len(self.X_reg), len(self.X_reg)))
         self.assertTrue(np.allclose(matrix, matrix.T))
         self.assertTrue(np.all(np.diag(matrix) == 0))
         self.assertIsNone(file)
@@ -450,18 +431,18 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
     def test_same_leaf_samples_have_zero_distance(self):
         """Samples that share the same leaf in every tree must have distance 0."""
         dist = DistanceRandomForestLCA()
-        dist.calculate_terminals(estimator=self.model, X=self.X)
+        dist.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         same_terminals = (dist.terminals[:, None, :] == dist.terminals[None, :, :]).all(axis=2)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=None)
         self.assertTrue(np.all(matrix[same_terminals] == 0.0))
 
     def test_memory_efficient_memmap_path_matches_in_memory(self):
         d1 = DistanceRandomForestLCA(memory_efficient=False)
-        d1.calculate_terminals(estimator=self.model, X=self.X)
+        d1.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         m1, _ = d1.calculate_distance_matrix(sample_indices=None)
 
         d2 = DistanceRandomForestLCA(memory_efficient=True, dir_distance_matrix=self.tmp_path)
-        d2.calculate_terminals(estimator=self.model, X=self.X)
+        d2.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         m2, f2 = d2.calculate_distance_matrix(sample_indices=None)
 
         self.assertTrue(isinstance(m2, np.memmap))
@@ -482,8 +463,8 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
 
     def test_sample_indices_slicing(self):
         dist = DistanceRandomForestLCA()
-        dist.calculate_terminals(estimator=self.model, X=self.X)
-        idx = np.random.RandomState(0).choice(len(self.X), size=20, replace=False)
+        dist.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
+        idx = np.random.RandomState(0).choice(len(self.X_reg), size=20, replace=False)
         matrix, _ = dist.calculate_distance_matrix(sample_indices=idx)
         self.assertEqual(matrix.shape, (20, 20))
         self.assertTrue(np.allclose(matrix, matrix.T))
@@ -520,11 +501,11 @@ class TestDistanceRandomForestLCA(unittest.TestCase):
     def test_lca_distance_le_terminal_distance(self):
         """Per-pair invariant: LCA distance ≤ terminal-node distance."""
         proximity = DistanceRandomForestProximity()
-        proximity.calculate_terminals(estimator=self.model, X=self.X)
+        proximity.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         pm, _ = proximity.calculate_distance_matrix(sample_indices=None)
 
         lca = DistanceRandomForestLCA()
-        lca.calculate_terminals(estimator=self.model, X=self.X)
+        lca.calculate_terminals(estimator=self.model_reg, X=self.X_reg)
         lm, _ = lca.calculate_distance_matrix(sample_indices=None)
 
         self.assertTrue(np.all(np.asarray(lm) <= np.asarray(pm) + 1e-6))
@@ -536,10 +517,7 @@ class TestTreeHelpers(unittest.TestCase):
     def setUp(self):
         X, y = make_classification(n_samples=30, n_features=4, random_state=0)
         self.tree = (
-            RandomForestClassifier(n_estimators=1, max_depth=3, random_state=0)
-            .fit(X, y)
-            .estimators_[0]
-            .tree_
+            RandomForestClassifier(n_estimators=1, max_depth=3, random_state=0).fit(X, y).estimators_[0].tree_
         )
 
     def test_compute_parent_array_root_is_minus_one(self):

--- a/test/test_distance.py
+++ b/test/test_distance.py
@@ -14,6 +14,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from fgclustering.distance import (
+    DistanceRandomForestBase,
     DistanceRandomForestLCA,
     DistanceRandomForestProximity,
     DistanceWasserstein,
@@ -561,6 +562,29 @@ class TestTreeHelpers(unittest.TestCase):
     def test_validate_mutually_exclusive_two_raises(self):
         with self.assertRaises(ValueError):
             _validate_mutually_exclusive(a=1, b=2, c=None)
+
+
+class TestDistanceRandomForestBase(unittest.TestCase):
+    """Contract tests for the abstract base class."""
+
+    def test_direct_instantiation_raises(self):
+        """`DistanceRandomForestBase` is abstract and cannot be instantiated directly."""
+        with self.assertRaises(TypeError):
+            DistanceRandomForestBase()
+
+    def test_abstract_methods_are_marked(self):
+        """Both interface methods must be exposed as abstract on the base class."""
+        self.assertTrue(
+            getattr(DistanceRandomForestBase.calculate_terminals, "__isabstractmethod__", False)
+        )
+        self.assertTrue(
+            getattr(DistanceRandomForestBase.calculate_distance_matrix, "__isabstractmethod__", False)
+        )
+
+    def test_concrete_subclasses_are_instantiable(self):
+        """Concrete subclasses implement the abstract methods and instantiate cleanly."""
+        DistanceRandomForestProximity()
+        DistanceRandomForestLCA()
 
 
 class TestDistanceWasserstein(unittest.TestCase):

--- a/test/test_forest_guided_clustering.py
+++ b/test/test_forest_guided_clustering.py
@@ -11,8 +11,8 @@ import pandas as pd
 
 from pathlib import Path
 
-from sklearn.datasets import make_classification
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import make_classification, make_regression
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from fgclustering.forest_guided_clustering import (
     forest_guided_clustering,
@@ -20,14 +20,58 @@ from fgclustering.forest_guided_clustering import (
     plot_forest_guided_clustering,
     plot_forest_guided_decision_paths,
     plot_forest_guided_feature_importance,
-    DistanceRandomForestProximity,
     ClusteringKMedoids,
 )
 
+from fgclustering.distance import DistanceRandomForestLCA, DistanceRandomForestProximity
 
 ############################################
 # Tests
 ############################################
+
+
+def _build_regression_forest(
+    random_state=0,
+    criterion="squared_error",
+    n_estimators=20,
+    max_depth=8,
+):
+    X, y = make_regression(
+        n_samples=100,
+        n_features=6,
+        random_state=random_state,
+    )
+    X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+    model = RandomForestRegressor(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        criterion=criterion,
+        random_state=random_state,
+    ).fit(X, y)
+    return X, y, model
+
+
+def _build_classification_forest(
+    random_state=42,
+):
+    # Generate test data
+    X, y = make_classification(
+        n_samples=50,
+        n_features=5,
+        n_informative=3,
+        n_redundant=1,
+        random_state=random_state,
+    )
+    X = pd.DataFrame(data=X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+    model = RandomForestClassifier(
+        max_depth=10,
+        max_features="sqrt",
+        max_samples=0.8,
+        bootstrap=True,
+        oob_score=True,
+        random_state=random_state,
+    ).fit(X, y)
+    return X, y, model
 
 
 class TestForestGuidedClustering(unittest.TestCase):
@@ -54,34 +98,8 @@ class TestForestGuidedClustering(unittest.TestCase):
             memory_efficient=True, dir_distance_matrix=self.tmp_path
         )
 
-        self.X, self.y, self.model = self._train_model()
-
-    def _train_model(self):
-
-        # Generate test data
-        X, y = make_classification(
-            n_samples=300,
-            n_features=10,
-            n_informative=4,
-            n_redundant=1,
-            n_classes=2,
-            n_clusters_per_class=1,
-            random_state=self.random_state,
-        )
-        X = pd.DataFrame(data=X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        y = y
-
-        model = RandomForestClassifier(
-            max_depth=10,
-            max_features="sqrt",
-            max_samples=0.8,
-            bootstrap=True,
-            oob_score=True,
-            random_state=self.random_state,
-        )
-        model.fit(X=X, y=y)
-
-        return X, y, model
+        self.X_clas, self.y_clas, self.model_clas = _build_classification_forest(self.random_state)
+        self.X_reg, self.y_reg, self.model_reg = _build_regression_forest(self.random_state)
 
     def tearDown(self):
         try:
@@ -92,9 +110,9 @@ class TestForestGuidedClustering(unittest.TestCase):
     def test_forest_guided_clustering_basic_run(self):
         # Run the forest-guided clustering
         result = forest_guided_clustering(
-            estimator=self.model,
-            X=self.X,
-            y=self.y,
+            estimator=self.model_clas,
+            X=self.X_clas,
+            y=self.y_clas,
             clustering_distance_metric=self.distance_metric,
             clustering_strategy=self.clustering_strategy,
             n_jobs=self.n_jobs,
@@ -111,17 +129,17 @@ class TestForestGuidedClustering(unittest.TestCase):
         with self.assertRaises(ValueError):
             forest_guided_clustering(
                 estimator="not_a_model",
-                X=self.X,
-                y=self.y,
+                X=self.X_clas,
+                y=self.y_clas,
                 clustering_distance_metric=self.distance_metric,
                 clustering_strategy=self.clustering_strategy,
             )
 
     def test_forest_guided_clustering_no_stable_clusters(self):
         result = forest_guided_clustering(
-            estimator=self.model,
-            X=self.X,
-            y=self.y,
+            estimator=self.model_clas,
+            X=self.X_clas,
+            y=self.y_clas,
             clustering_distance_metric=self.distance_metric,
             clustering_strategy=self.clustering_strategy,
             JI_discart_value=1.1,
@@ -130,9 +148,9 @@ class TestForestGuidedClustering(unittest.TestCase):
 
     def test_forest_guided_clustering_memory_efficient(self):
         result = forest_guided_clustering(
-            estimator=self.model,
-            X=self.X,
-            y=self.y,
+            estimator=self.model_clas,
+            X=self.X_clas,
+            y=self.y_clas,
             clustering_distance_metric=self.distance_metric_memory_eff,
             clustering_strategy=self.clustering_strategy,
             JI_discart_value=self.JI_discart_value,
@@ -142,23 +160,11 @@ class TestForestGuidedClustering(unittest.TestCase):
         self.assertIsInstance(obj=result.best_k, cls=int)
 
     def test_forest_guided_clustering_with_lca_distance_regression(self):
-        from sklearn.datasets import make_regression
-        from sklearn.ensemble import RandomForestRegressor
-
-        from fgclustering import forest_guided_clustering
-        from fgclustering.clustering import ClusteringKMedoids
-        from fgclustering.distance import DistanceRandomForestLCA
-
-        X, y = make_regression(n_samples=100, n_features=6, random_state=0)
-        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        model = RandomForestRegressor(n_estimators=20, max_depth=8, random_state=0).fit(
-            X, y
-        )
 
         result = forest_guided_clustering(
-            estimator=model,
-            X=X,
-            y=pd.Series(y),
+            estimator=self.model_reg,
+            X=self.X_reg,
+            y=pd.Series(self.y_reg),
             clustering_distance_metric=DistanceRandomForestLCA(),
             clustering_strategy=ClusteringKMedoids(random_state=0),
             k=(2, 4),
@@ -170,38 +176,13 @@ class TestForestGuidedClustering(unittest.TestCase):
         self.assertIn(result.best_k, [2, 3, 4] + [None])
         self.assertEqual(set(result.cluster_labels.keys()), {2, 3, 4})
 
-    def test_forest_guided_clustering_with_lca_regressor(self):
-        from sklearn.datasets import make_regression
-        from sklearn.ensemble import RandomForestRegressor
-        from fgclustering.distance import DistanceRandomForestLCA
-        from fgclustering.clustering import ClusteringKMedoids
-        from fgclustering import forest_guided_clustering
-
-        X, y = make_regression(n_samples=80, n_features=6, random_state=0)
-        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
-        model = RandomForestRegressor(n_estimators=15, max_depth=6, random_state=0).fit(X, y)
-
-        result = forest_guided_clustering(
-            estimator=model,
-            X=X,
-            y=pd.Series(y),
-            clustering_distance_metric=DistanceRandomForestLCA(),
-            clustering_strategy=ClusteringKMedoids(random_state=0),
-            k=(2, 3),
-            JI_bootstrap_iter=3,
-            JI_bootstrap_sample_size=0.8,
-            random_state=0,
-            verbose=0,
-        )
-        self.assertEqual(set(result.cluster_labels.keys()), {2, 3})
-
     def test_forest_guided_feature_importance_output(self):
 
-        cluster_labels = np.random.randint(low=0, high=3, size=self.X.shape[0])
+        cluster_labels = np.random.randint(low=0, high=3, size=self.X_clas.shape[0])
 
         result = forest_guided_feature_importance(
-            X=self.X,
-            y=self.y,
+            X=self.X_clas,
+            y=self.y_clas,
             cluster_labels=cluster_labels,
             feature_importance_distance_metric="wasserstein",
         )
@@ -211,22 +192,18 @@ class TestForestGuidedClustering(unittest.TestCase):
         self.assertIn(member="data_clustering", container=result)
 
         # test shape of each output
-        self.assertEqual(
-            first=result.feature_importance_local.shape[0], second=self.X.shape[1]
-        )
-        self.assertEqual(
-            first=result.feature_importance_global.shape[0], second=self.X.shape[1]
-        )
-        self.assertEqual(first=result.data_clustering.shape[0], second=self.X.shape[0])
+        self.assertEqual(first=result.feature_importance_local.shape[0], second=self.X_clas.shape[1])
+        self.assertEqual(first=result.feature_importance_global.shape[0], second=self.X_clas.shape[1])
+        self.assertEqual(first=result.data_clustering.shape[0], second=self.X_clas.shape[0])
 
     def test_forest_guided_feature_importance_with_y_pred(self):
         rng = np.random.default_rng(seed=0)
-        cluster_labels = rng.integers(low=0, high=3, size=self.X.shape[0])
-        y_pred = pd.Series(data=self.model.predict(X=self.X))
+        cluster_labels = rng.integers(low=0, high=3, size=self.X_clas.shape[0])
+        y_pred = pd.Series(data=self.model_clas.predict(X=self.X_clas))
 
         result = forest_guided_feature_importance(
-            X=self.X,
-            y=self.y,
+            X=self.X_clas,
+            y=self.y_clas,
             cluster_labels=cluster_labels,
             y_pred=y_pred,
             feature_importance_distance_metric="wasserstein",
@@ -234,9 +211,7 @@ class TestForestGuidedClustering(unittest.TestCase):
         df = result.data_clustering
 
         self.assertIn(member="predicted_target", container=df.columns)
-        self.assertEqual(
-            first=list(df.columns[:3]), second=["cluster", "target", "predicted_target"]
-        )
+        self.assertEqual(first=list(df.columns[:3]), second=["cluster", "target", "predicted_target"])
         # Returned frame is sort_values(...); sort_index() restores rows to original sample order.
         df_sorted = df.sort_index()
         np.testing.assert_array_equal(
@@ -245,26 +220,26 @@ class TestForestGuidedClustering(unittest.TestCase):
         )
         np.testing.assert_array_equal(
             df_sorted["target"].to_numpy(),
-            np.asarray(self.y),
+            np.asarray(self.y_clas),
         )
 
     def test_forest_guided_feature_importance_invalid_distance_metric(self):
 
-        cluster_labels = np.random.randint(low=0, high=3, size=self.X.shape[0])
+        cluster_labels = np.random.randint(low=0, high=3, size=self.X_clas.shape[0])
 
         with self.assertRaises(ValueError):
             forest_guided_feature_importance(
-                X=self.X,
-                y=self.y,
+                X=self.X_clas,
+                y=self.y_clas,
                 cluster_labels=cluster_labels,
                 feature_importance_distance_metric="invalid_metric",
             )
 
     def test_plot_forest_guided_clustering(self):
         result = forest_guided_clustering(
-            estimator=self.model,
-            X=self.X,
-            y=self.y,
+            estimator=self.model_clas,
+            X=self.X_clas,
+            y=self.y_clas,
             clustering_distance_metric=self.distance_metric,
             clustering_strategy=self.clustering_strategy,
             n_jobs=self.n_jobs,
@@ -289,10 +264,10 @@ class TestForestGuidedClustering(unittest.TestCase):
     def test_plot_forest_guided_feature_importance(self):
         k = 3
         feature_importance_local = pd.DataFrame(
-            data=np.random.rand(self.X.shape[1], k), index=self.X.columns
+            data=np.random.rand(self.X_clas.shape[1], k), index=self.X_clas.columns
         )
         feature_importance_global = pd.Series(
-            data=np.random.rand(self.X.shape[1]), index=self.X.columns
+            data=np.random.rand(self.X_clas.shape[1]), index=self.X_clas.columns
         )
 
         save = os.path.join(self.tmp_path, "test_fgc")
@@ -312,20 +287,18 @@ class TestForestGuidedClustering(unittest.TestCase):
 
     def test_plot_forest_guided_decision_paths(self):
 
-        data_clustering = self.X.copy()
-        data_clustering["target"] = self.y
-        data_clustering["cluster"] = np.random.randint(
-            low=0, high=3, size=self.X.shape[0]
-        )
-        data_clustering = data_clustering[["target", "cluster"] + list(self.X.columns)]
+        data_clustering = self.X_clas.copy()
+        data_clustering["target"] = self.y_clas
+        data_clustering["cluster"] = np.random.randint(low=0, high=3, size=self.X_clas.shape[0])
+        data_clustering = data_clustering[["target", "cluster"] + list(self.X_clas.columns)]
 
         save = os.path.join(self.tmp_path, "test_fgc")
 
         feature_importance_global = pd.Series(
-            data=np.random.rand(self.X.shape[1]), index=self.X.columns
+            data=np.random.rand(self.X_clas.shape[1]), index=self.X_clas.columns
         )
         feature_importance_local = pd.DataFrame(
-            data=np.random.rand(self.X.shape[1], 3), index=self.X.columns
+            data=np.random.rand(self.X_clas.shape[1], 3), index=self.X_clas.columns
         )
 
         plot_forest_guided_decision_paths(
@@ -356,16 +329,16 @@ class TestForestGuidedClustering(unittest.TestCase):
 
     def test_color_spec(self):
         result = forest_guided_clustering(
-            estimator=self.model,
-            X=self.X,
-            y=self.y,
+            estimator=self.model_clas,
+            X=self.X_clas,
+            y=self.y_clas,
             clustering_distance_metric=self.distance_metric,
             clustering_strategy=self.clustering_strategy,
             n_jobs=self.n_jobs,
         )
         results_FI = forest_guided_feature_importance(
-            X=self.X,
-            y=self.y,
+            X=self.X_clas,
+            y=self.y_clas,
             cluster_labels=result.cluster_labels[result.best_k],
         )
 

--- a/test/test_forest_guided_clustering.py
+++ b/test/test_forest_guided_clustering.py
@@ -170,6 +170,31 @@ class TestForestGuidedClustering(unittest.TestCase):
         self.assertIn(result.best_k, [2, 3, 4] + [None])
         self.assertEqual(set(result.cluster_labels.keys()), {2, 3, 4})
 
+    def test_forest_guided_clustering_with_lca_regressor(self):
+        from sklearn.datasets import make_regression
+        from sklearn.ensemble import RandomForestRegressor
+        from fgclustering.distance import DistanceRandomForestLCA
+        from fgclustering.clustering import ClusteringKMedoids
+        from fgclustering import forest_guided_clustering
+
+        X, y = make_regression(n_samples=80, n_features=6, random_state=0)
+        X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+        model = RandomForestRegressor(n_estimators=15, max_depth=6, random_state=0).fit(X, y)
+
+        result = forest_guided_clustering(
+            estimator=model,
+            X=X,
+            y=pd.Series(y),
+            clustering_distance_metric=DistanceRandomForestLCA(),
+            clustering_strategy=ClusteringKMedoids(random_state=0),
+            k=(2, 3),
+            JI_bootstrap_iter=3,
+            JI_bootstrap_sample_size=0.8,
+            random_state=0,
+            verbose=0,
+        )
+        self.assertEqual(set(result.cluster_labels.keys()), {2, 3})
+
     def test_forest_guided_feature_importance_output(self):
 
         cluster_labels = np.random.randint(low=0, high=3, size=self.X.shape[0])

--- a/test/test_forest_guided_clustering.py
+++ b/test/test_forest_guided_clustering.py
@@ -39,6 +39,7 @@ def _build_regression_forest(
     X, y = make_regression(
         n_samples=100,
         n_features=6,
+        n_informative=6,
         random_state=random_state,
     )
     X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])


### PR DESCRIPTION
## Summary

This pull request is the **PR-B** consolidation step in the inner-node proximity series. It introduces a shared `DistanceRandomForestBase` parent class, fixes type hints so `DistanceRandomForestLCA` is correctly advertised as a supported `clustering_distance_metric`, removes ~30 LOC of duplicated memmap bookkeeping per distance class, and unifies the unit-test fixtures so `test/test_distance.py` and `test/test_forest_guided_clustering.py` share a single classifier and three regressors (`squared_error`, `friedman_mse`, `absolute_error`). It also fixes an `ImportError` introduced by the refactor in `test/test_forest_guided_clustering.py`. **No public behavior change**, no new collapse strategies — strictly a structural and hygiene PR.

## Motivation

After PR-A added three ancestor-collapse strategies (`min_samples_in_node`, `max_depth_for_proximity`, `min_node_variance`) and `DistanceRandomForestLCA`, two structural problems remained:

1. **Duplicated infrastructure.** `DistanceRandomForestProximity` and `DistanceRandomForestLCA` both reimplemented memmap allocation, the disk-space safety check, and `remove_distance_matrix`.
2. **Misleading type hints.** `clustering_distance_metric` parameters were typed as `DistanceRandomForestProximity` everywhere, even though `DistanceRandomForestLCA` is a fully supported alternative — making LCA look unofficial to users and to type checkers.

PR-B addresses both, plus the related test-suite duplication that grew in parallel.

## What changed

### Added

- **`DistanceRandomForestBase`**: shared base class for `DistanceRandomForestProximity` and `DistanceRandomForestLCA`. Owns the memmap configuration, the `terminals` attribute, the `_allocate_distance_matrix` helper, and the `remove_distance_matrix` cleanup logic. Exported from the `fgclustering` package for external type hints. Both existing distance classes now inherit from it.
- **Targeted unit tests** for `_compute_parent_array`, `_compute_node_depths`, `_build_leaf_to_ancestor_map`, and `_validate_mutually_exclusive` in a new `TestTreeHelpers` class.
- **Per-pair invariant test** `test_lca_distance_le_terminal_distance` proving LCA distance ≤ terminal-node distance for any pair.
- **Baseline-on-regressor smoke tests** for `min_samples_in_node` and `max_depth_for_proximity` (now folded into the existing `*_one_matches_baseline` / `*_large_matches_baseline` tests, see below).
- **Integration test** `test_forest_guided_clustering_with_lca_regressor` driving `forest_guided_clustering()` through `DistanceRandomForestLCA` end to end.

### Changed

- **Type hints** on `distance_metric` parameters in `ClusteringKMedoids.run_clustering`, `ClusteringClara.run_clustering`, `Optimizer.__init__`, and `forest_guided_clustering()` now reference **`DistanceRandomForestBase`** instead of `DistanceRandomForestProximity`, so `DistanceRandomForestLCA` is correctly advertised as supported.
- **De-duplication**:
  - `DistanceRandomForestProximity.remove_distance_matrix` and `DistanceRandomForestLCA.remove_distance_matrix` deleted; both classes now inherit from `DistanceRandomForestBase`.
  - `DistanceRandomForestProximity.calculate_distance_matrix` and `DistanceRandomForestLCA.calculate_distance_matrix` use the inherited `_allocate_distance_matrix` helper, removing ~30 LOC of duplicated memmap bookkeeping per class.
- **Test infrastructure cleanup**:
  - All imports moved to module level.
  - Keyword-style `unittest` assertion arguments (`first=`, `second=`, `expr=`, `obj=`, `a=`, `v=`) replaced with positional form, matching the rest of the test suite.
  - `_train_regression_model` consolidated into a module-level **`_build_regression_forest`** helper shared across test classes.

### Fixed

- **`ImportError` in `test/test_forest_guided_clustering.py`**: `DistanceRandomForestProximity` is now imported from `fgclustering.distance` instead of `fgclustering.forest_guided_clustering`. The latter only re-exports `DistanceRandomForestBase` after the refactor, so the previous import path raised `ImportError` at collection time.

### Test unification (additional)

- **Shared fixtures**: `setUp` in both test modules builds one classifier and three regressors (`squared_error`, `friedman_mse`, `absolute_error`) once via module-level `_build_classification_forest` / `_build_regression_forest` helpers; tests reuse them via `self.model_clas`, `self.model_reg_squared`, `self.model_reg_friedman`, `self.model_reg_absolute` (`self.model_reg` in `test_forest_guided_clustering.py`). All inline `make_classification` / `make_regression` / `RandomForestRegressor` setup inside individual tests removed.
- **Renames**: `self.X → self.X_clas`, `self.y → self.y_clas`, `self.model → self.model_clas` so classification and regression fixtures can coexist.
- **`test_distance.py`**:
  - The dedicated `*_baseline_on_regressor` tests for `min_samples_in_node` and `max_depth_for_proximity` are now folded into `test_min_samples_in_node_one_matches_baseline` and `test_max_depth_for_proximity_large_matches_baseline`, which assert baseline parity on **both** classifier and regressor.
  - **Dropped** the `*_monotonicity` tests for `min_samples_in_node` and `max_depth_for_proximity`: off-diagonal mean monotonicity is not a contracted invariant of bottom-up ancestor collapse and the tests were flaky on small synthetic forests. Direction-of-effect is still covered by the `*_collapses_to_root` and `*_large_matches_baseline` tests.
  - Pairwise mutual-exclusivity tests renamed to a uniform `test_<a>_mutually_exclusive_with_<b>` scheme alongside `test_all_three_mutually_exclusive`.
- **`test_forest_guided_clustering.py`**: removed the duplicated `test_forest_guided_clustering_with_lca_regressor` (its coverage is fully subsumed by `test_forest_guided_clustering_with_lca_distance_regression`, which now uses the shared `self.model_reg` fixture).
- **`fgclustering/distance.py`**: minor docstring/formatting polish in `DistanceRandomForestBase` (wording "consumers" → "users"; a few short one-liners no longer artificially line-wrapped). No behavior change.

## Out of scope

- **No new public parameters, no new distance classes, no algorithmic changes.** The four collapse strategies (`min_samples_in_node`, `max_depth_for_proximity`, `min_node_variance`) and `DistanceRandomForestLCA` retain their existing API, validation, and dispatch.
- The known limitation that **`DistanceRandomForestLCA` paired with `ClusteringClara`** is not fully LCA-consistent end-to-end is unchanged and tracked as a follow-up — `_calculate_inertia` and `_asign_labels` in `fgclustering/clustering.py` still read `self.terminals` directly.

## How to review

- `fgclustering/distance.py`: confirm `DistanceRandomForestBase` correctly owns the memmap allocation and cleanup, and that both subclasses’ `calculate_distance_matrix` paths produce the same shape/symmetric/zero-diagonal output as before. The `test_calculate_distance_matrix_*` and `test_memory_efficient_memmap_path_matches_in_memory` tests cover this.
- `fgclustering/__init__.py`: `DistanceRandomForestBase` is exported alongside `DistanceRandomForestProximity` and `DistanceRandomForestLCA`.
- `fgclustering/{clustering,optimizer,forest_guided_clustering}.py`: type hints on `distance_metric` / `clustering_distance_metric` reference `DistanceRandomForestBase`.
- `test/test_distance.py` and `test/test_forest_guided_clustering.py`: `setUp` builds shared fixtures, individual tests use them; `TestTreeHelpers` class covers internal helpers; `test_lca_distance_le_terminal_distance` enforces the LCA ≤ terminal-distance invariant.

## Files

| File | Role |
|------|------|
| `fgclustering/distance.py` | New `DistanceRandomForestBase` parent; subclasses de-duplicated |
| `fgclustering/__init__.py` | Export `DistanceRandomForestBase` |
| `fgclustering/clustering.py` | Type-hint widening to `DistanceRandomForestBase` |
| `fgclustering/optimizer.py` | Type-hint widening to `DistanceRandomForestBase` |
| `fgclustering/forest_guided_clustering.py` | Type-hint widening to `DistanceRandomForestBase` |
| `test/test_distance.py` | Shared fixtures, `TestTreeHelpers`, LCA invariant test, cleanup |
| `test/test_forest_guided_clustering.py` | Shared fixtures, fixed import path, deduplicated LCA-on-regressor test |
| `CHANGELOG.md` | PR-B and PR-B test-unification entries under *[Unreleased]* |